### PR TITLE
Bring back the id column & render empty fragment

### DIFF
--- a/web/src/components/ShiftTable/ShiftTable.tsx
+++ b/web/src/components/ShiftTable/ShiftTable.tsx
@@ -17,30 +17,32 @@ const ShiftTable = ({ request, tempAgencies }: ShiftTableProps) => {
     ColumnDef<FindWorkRequestQuery['workRequest']['shifts'][0]>[]
   >(
     () => [
-      // TODO: Batch-edit shifts
-      // {
-      //   accessorKey: 'id',
-      //   header: ({ table }) => (
-      //     <Checkbox
-      //       checked={
-      //         (table.getIsAllPageRowsSelected() ||
-      //           (table.getIsSomePageRowsSelected() &&
-      //             'indeterminate')) as boolean
-      //       }
-      //       onCheckedChange={(value) =>
-      //         table.toggleAllPageRowsSelected(!!value)
-      //       }
-      //       aria-label="Select all"
-      //     />
-      //   ),
-      //   cell: ({ row }) => (
-      //     <Checkbox
-      //       checked={row.getIsSelected()}
-      //       onCheckedChange={(value) => row.toggleSelected(!!value)}
-      //       aria-label="Select row"
-      //     />
-      //   ),
-      // },
+      {
+        // TODO: Batch-edit shifts
+        accessorKey: 'id',
+        header: ({ table }) => (
+          <></>
+          // <Checkbox
+          //   checked={
+          //     (table.getIsAllPageRowsSelected() ||
+          //       (table.getIsSomePageRowsSelected() &&
+          //         'indeterminate')) as boolean
+          //   }
+          //   onCheckedChange={(value) =>
+          //     table.toggleAllPageRowsSelected(!!value)
+          //   }
+          //   aria-label="Select all"
+          // />
+        ),
+        cell: ({ row }) => (
+          <></>
+          // <Checkbox
+          //   checked={row.getIsSelected()}
+          //   onCheckedChange={(value) => row.toggleSelected(!!value)}
+          //   aria-label="Select row"
+          // />
+        ),
+      },
       {
         accessorKey: 'name',
         header: 'Ploegendienst',


### PR DESCRIPTION
This PR fixes the bug where we could not change the agency assigned. 

![image](https://github.com/user-attachments/assets/9fde3ce9-e3e3-41f2-9bee-62a0c6d9d973)


Fixes #168 