### PR TITLE
Add hoursPlanned and hoursWorked to the shifts

### DIFF
--- a/api/db/migrations/20240912062634_add_hours_to_shifts/migration.sql
+++ b/api/db/migrations/20240912062634_add_hours_to_shifts/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "Shift" ADD COLUMN     "hoursPlanned" DECIMAL(65,30),
+ADD COLUMN     "hoursWorked" DECIMAL(65,30);

--- a/api/db/schema.prisma
+++ b/api/db/schema.prisma
@@ -141,6 +141,8 @@ model Shift {
   rating        Int?
   tempAgency    TempAgency?  @relation(fields: [tempAgencyId], references: [id])
   tempAgencyId  String?
+  hoursPlanned  Decimal?
+  hoursWorked   Decimal?
 }
 
 enum ShiftStatus {


### PR DESCRIPTION
This PR adds hoursPlanned and hoursWorked to the shifts.

Since this is a database change, we need to run `yarn rw prisma migrate dev` after merging these changes.

Fixes #131 