### PR TITLE
Fix rendering job profile rendering '0' without context

### DIFF
--- a/web/src/components/JobProfileCard/JobProfileCard.tsx
+++ b/web/src/components/JobProfileCard/JobProfileCard.tsx
@@ -45,18 +45,14 @@ const JobProfileCard = ({ item }: JobProfileCardProps) => {
           <span>Max. reisafstand: </span>
           <span className="font-semibold">{item.maxTravelDistance} km.</span>
         </div>
-        {item.kmAllowance && (
-          <div>
-            Km. vergoeding:{' '}
-            <span className="font-semibold"> €{item.kmAllowance}</span>
-          </div>
-        )}
+        <div>
+          Km. vergoeding:{' '}
+          <span className="font-semibold"> €{item.kmAllowance}</span>
+        </div>
         <Separator className="my-4 bg-primary-foreground/70" />
-        {item.totalBudgetPerHour && (
-          <div className="font-semibold">
-            Budget €{item.totalBudgetPerHour}/uur
-          </div>
-        )}
+        <div className="font-semibold">
+          Budget €{item.totalBudgetPerHour}/uur
+        </div>
       </CardContent>
       <CardFooter className="-mt-2 hyphens-auto text-sm">
         {item.comment}


### PR DESCRIPTION
This PR fixes the bug rendering '0' without labels when a value is not set. Fixes #176 

<img width="302" alt="Screenshot 2024-09-12 at 16 20 23" src="https://github.com/user-attachments/assets/1620c607-a9fa-41b5-82a2-a0ee6ab1e4a9">

<img width="335" alt="Screenshot 2024-09-12 at 16 23 35" src="https://github.com/user-attachments/assets/3880c08d-b4e4-40db-b4db-2ed84fcae790">
