### PR TITLE
Error out when there are more shifts to remove than the number of unfulfilled shifts

### DIFF
--- a/api/src/services/workRequests/workRequests.ts
+++ b/api/src/services/workRequests/workRequests.ts
@@ -86,11 +86,8 @@ export const updateWorkRequest: MutationResolvers['updateWorkRequest'] =
         status: 'UNFULFILLED',
       },
     })
-    const numFulfilledShifts = await db.shift.count({
-      where: { workRequestId: id, status: 'FULFILLED' },
-    })
 
-    if (numShiftsToRemove > numFulfilledShifts)
+    if (unfulfilledShifts.length - numShiftsToRemove < 0)
       throw new ForbiddenError(
         'Het aantal te verwijderen diensten is groter dan het aantal diensten met vervulde status.'
       )


### PR DESCRIPTION
This is to fix the bug introduced in #191 .