### PR TITLE
Making the "province" field of the address optional

### DIFF
--- a/api/db/migrations/20240913181650_make_province_optional/migration.sql
+++ b/api/db/migrations/20240913181650_make_province_optional/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Address" ALTER COLUMN "province" DROP NOT NULL;

--- a/api/db/schema.prisma
+++ b/api/db/schema.prisma
@@ -73,7 +73,7 @@ model Address {
   houseNumberAddition String?
   postalCode          String
   city                String
-  province            String
+  province            String?
   country             String        @default("Netherlands")
   workRequest         WorkRequest[]
   createdBy           User?         @relation(fields: [userId], references: [id])


### PR DESCRIPTION
This PR makes the province field of the address model optional.