### PR TITLE
Make province as nullable in SDL

### DIFF
--- a/api/src/graphql/addresses.sdl.ts
+++ b/api/src/graphql/addresses.sdl.ts
@@ -8,7 +8,7 @@ export const schema = gql`
     houseNumberAddition: String
     postalCode: String!
     city: String!
-    province: String!
+    province: String
     country: String!
     workRequest: [WorkRequest]!
   }


### PR DESCRIPTION
We were having the issue of GraphQL expecting that the province is required, but the province field was nullable on the database.

![image](https://github.com/user-attachments/assets/f9b856c5-3ff2-44df-9571-8d9f666ad7b6)

This PR fixes the issue by making the GraphQL SDL file's definition of "province" nullable.



