### PR TITLE
Add comments schema to the database model [skip ci]

### DIFF
--- a/api/db/migrations/20240914142851_add_comment_model/migration.sql
+++ b/api/db/migrations/20240914142851_add_comment_model/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE "Comment" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "body" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "workRequestId" TEXT NOT NULL,
+
+    CONSTRAINT "Comment_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "Comment" ADD CONSTRAINT "Comment_workRequestId_fkey" FOREIGN KEY ("workRequestId") REFERENCES "WorkRequest"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Comment" ADD CONSTRAINT "Comment_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/api/db/schema.prisma
+++ b/api/db/schema.prisma
@@ -32,6 +32,7 @@ model User {
   jobProfile            JobProfile[]
   certificate           Certificate[]
   clientBusinessCreated ClientBusiness[]
+  commentsCreated       Comment[]
 }
 
 enum Role {
@@ -55,6 +56,7 @@ model WorkRequest {
   status       WorkRequestStatus @default(DRAFT)
   createdBy    User?             @relation(fields: [userId], references: [id])
   userId       String?
+  comments     Comment[]
 }
 
 enum WorkRequestStatus {
@@ -171,4 +173,15 @@ model Workplace {
   clientBusinessId String
   address          Address        @relation(fields: [addressId], references: [id])
   addressId        String
+}
+
+model Comment {
+  id            String      @id @default(cuid())
+  createdAt     DateTime    @default(now())
+  updatedAt     DateTime    @updatedAt
+  body          String
+  workRequest   WorkRequest @relation(fields: [workRequestId], references: [id])
+  commentedBy   User        @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId        String
+  workRequestId String
 }


### PR DESCRIPTION
This PR adds comments model to the database schema.

After merging, we need to run `prisma migrate dev` ⭐️

Resolves #107 