### PR TITLE
feat(jobProfile): Can edit job profiles

### DIFF
--- a/api/src/services/jobProfiles/jobProfiles.ts
+++ b/api/src/services/jobProfiles/jobProfiles.ts
@@ -5,6 +5,7 @@ import type {
 } from 'types/graphql'
 
 import { validate } from '@redwoodjs/api'
+import { SyntaxError } from '@redwoodjs/graphql-server'
 
 import { db } from 'src/lib/db'
 
@@ -54,9 +55,21 @@ export const updateJobProfile: MutationResolvers['updateJobProfile'] = ({
   })
 }
 
-export const deleteJobProfile: MutationResolvers['deleteJobProfile'] = ({
+export const deleteJobProfile: MutationResolvers['deleteJobProfile'] = async ({
   id,
 }) => {
+  const linkedWorkRequests = await db.workRequest.findMany({
+    where: {
+      jobProfileId: id,
+    },
+  })
+
+  if (linkedWorkRequests.length > 0) {
+    throw new SyntaxError(
+      'Er zijn werkaanvragen gekoppeld aan dit functieprofiel. Je kunt alleen functieprofielen zonder werkaanvragen verwijderen.'
+    )
+  }
+
   return db.jobProfile.delete({
     where: { id },
   })

--- a/api/src/services/jobProfiles/jobProfiles.ts
+++ b/api/src/services/jobProfiles/jobProfiles.ts
@@ -9,7 +9,7 @@ import { validate } from '@redwoodjs/api'
 import { db } from 'src/lib/db'
 
 export const jobProfiles: QueryResolvers['jobProfiles'] = () => {
-  return db.jobProfile.findMany()
+  return db.jobProfile.findMany({ orderBy: { createdAt: 'desc' } })
 }
 
 export const jobProfile: QueryResolvers['jobProfile'] = ({ id }) => {

--- a/web/src/components/AddJobProfileModal/AddJobProfileModal.tsx
+++ b/web/src/components/AddJobProfileModal/AddJobProfileModal.tsx
@@ -8,7 +8,7 @@ import { z } from 'zod'
 
 import { FormError } from '@redwoodjs/forms'
 import { useMutation } from '@redwoodjs/web'
-import { Toaster, toast } from '@redwoodjs/web/toast'
+import { toast } from '@redwoodjs/web/toast'
 
 import ButtonWithLoader from 'src/components/ButtonWithLoader'
 import { QUERY as JobProfilesQuery } from 'src/components/JobProfilesCell'
@@ -139,7 +139,6 @@ const AddJobProfileModal = ({
 
   return (
     <Dialog open={open} onOpenChange={() => setOpen((c) => !c)}>
-      <Toaster />
       <DialogTrigger asChild>
         {trigger || (
           <Button className="mb-4 mt-12 flex gap-1 bg-black p-5 text-lg text-accent shadow-md shadow-accent/20 hover:bg-accent hover:text-white">

--- a/web/src/components/AddJobProfileModal/AddJobProfileModal.tsx
+++ b/web/src/components/AddJobProfileModal/AddJobProfileModal.tsx
@@ -3,7 +3,10 @@ import { ReactNode, useState } from 'react'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { CirclePlus, MessageSquareWarningIcon } from 'lucide-react'
 import { useForm } from 'react-hook-form'
-import { JobProfilesQuery as JobProfilesQueryType } from 'types/graphql'
+import {
+  JobProfilesQuery as JobProfilesQueryType,
+  UpdateJobProfileMutation,
+} from 'types/graphql'
 import { z } from 'zod'
 
 import { FormError } from '@redwoodjs/forms'
@@ -53,6 +56,7 @@ const UPDATE_JOB_PROFILE = gql`
   ) {
     updateJobProfile(id: $id, input: $input) {
       id
+      name
     }
   }
 `
@@ -119,8 +123,12 @@ const AddJobProfileModal = ({
   })
 
   const [update, { loading: updateLoading }] = useMutation(UPDATE_JOB_PROFILE, {
-    onCompleted: () => {
-      toast.success('Bijgewerkt')
+    onCompleted: (data: UpdateJobProfileMutation) => {
+      toast.success(
+        <>
+          Bijgewerkt: <b>{data.updateJobProfile.name}</b>
+        </>
+      )
       form.reset()
       setOpen(false)
     },

--- a/web/src/components/AddJobProfileModal/AddJobProfileModal.tsx
+++ b/web/src/components/AddJobProfileModal/AddJobProfileModal.tsx
@@ -11,10 +11,11 @@ import { useMutation } from '@redwoodjs/web'
 import { toast } from '@redwoodjs/web/toast'
 
 import ButtonWithLoader from 'src/components/ButtonWithLoader'
+import ConfirmAction from 'src/components/ConfirmAction/ConfirmAction'
 import { QUERY as JobProfilesQuery } from 'src/components/JobProfilesCell'
+import { Button } from 'src/components/ui/button'
 import { Switch } from 'src/components/ui/switch'
 
-import { Button } from '../ui/button'
 import {
   Dialog,
   DialogContent,
@@ -51,6 +52,14 @@ const UPDATE_JOB_PROFILE = gql`
     $input: UpdateJobProfileInput!
   ) {
     updateJobProfile(id: $id, input: $input) {
+      id
+    }
+  }
+`
+
+const DELETE_JOB_PROFILE = gql`
+  mutation DeleteJobProfileMutation($id: String!) {
+    deleteJobProfile(id: $id) {
       id
     }
   }
@@ -121,6 +130,19 @@ const AddJobProfileModal = ({
     refetchQueries: [{ query: JobProfilesQuery }],
   })
 
+  const [deleteProfile, { loading: deleteLoading }] = useMutation(
+    DELETE_JOB_PROFILE,
+    {
+      onCompleted: () => {
+        toast.success('Verwijderd')
+      },
+      onError: (e) => {
+        toast.error(e.message)
+      },
+      refetchQueries: [{ query: JobProfilesQuery }],
+    }
+  )
+
   function onSubmit(data: z.infer<typeof formSchema>) {
     if (currentJobProfile) {
       return update({
@@ -135,6 +157,10 @@ const AddJobProfileModal = ({
         input: data,
       },
     })
+  }
+
+  function handleDeleteProfile() {
+    deleteProfile({ variables: { id: currentJobProfile.id } })
   }
 
   return (
@@ -404,10 +430,27 @@ const AddJobProfileModal = ({
               )}
             />
             <DialogFooter>
+              <ConfirmAction
+                onConfirm={handleDeleteProfile}
+                title="Verwijderen profiel?"
+                description="U gaat het functieprofiel verwijderen"
+                actionText="Verwijderen"
+                loading={deleteLoading}
+              >
+                Verwijderen
+              </ConfirmAction>
+              <Button
+                type="button"
+                onClick={() => setOpen(false)}
+                disabled={deleteLoading}
+              >
+                Annuleren
+              </Button>
               <ButtonWithLoader
                 type="submit"
                 loading={loading || updateLoading}
                 className="text-accent brightness-200 hover:brightness-100"
+                disabled={deleteLoading}
               >
                 {currentJobProfile ? 'Bijwerken' : 'Aanmaken'}
               </ButtonWithLoader>

--- a/web/src/components/ConfirmAction/ConfirmAction.stories.tsx
+++ b/web/src/components/ConfirmAction/ConfirmAction.stories.tsx
@@ -1,0 +1,26 @@
+// Pass props to your component by passing an `args` object to your story
+//
+// ```tsx
+// export const Primary: Story = {
+//  args: {
+//    propName: propValue
+//  }
+// }
+// ```
+//
+// See https://storybook.js.org/docs/react/writing-stories/args.
+
+import type { Meta, StoryObj } from '@storybook/react'
+
+import ConfirmAction from './ConfirmAction'
+
+const meta: Meta<typeof ConfirmAction> = {
+  component: ConfirmAction,
+  tags: ['autodocs'],
+}
+
+export default meta
+
+type Story = StoryObj<typeof ConfirmAction>
+
+export const Primary: Story = {}

--- a/web/src/components/ConfirmAction/ConfirmAction.test.tsx
+++ b/web/src/components/ConfirmAction/ConfirmAction.test.tsx
@@ -1,0 +1,22 @@
+import { render } from '@redwoodjs/testing/web'
+
+import ConfirmAction from './ConfirmAction'
+
+//   Improve this test with help from the Redwood Testing Doc:
+//    https://redwoodjs.com/docs/testing#testing-components
+
+describe('ConfirmAction', () => {
+  it('renders successfully', () => {
+    expect(() => {
+      render(
+        <ConfirmAction
+          title="Confirm this action"
+          description="Please confirm this action"
+          onConfirm={() => {}}
+        >
+          Bevestigen
+        </ConfirmAction>
+      )
+    }).not.toThrow()
+  })
+})

--- a/web/src/components/ConfirmAction/ConfirmAction.tsx
+++ b/web/src/components/ConfirmAction/ConfirmAction.tsx
@@ -1,0 +1,68 @@
+import { ReactNode } from 'react'
+
+import { ApolloError } from '@apollo/client/errors'
+
+import ButtonWithLoader from 'src/components/ButtonWithLoader/ButtonWithLoader'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from 'src/components/ui/alert-dialog'
+import { buttonVariants } from 'src/components/ui/button'
+
+type ConfirmActionProps = {
+  children: ReactNode
+  title: string
+  description: string
+  actionText?: string
+  onConfirm: () => void
+  error?: ApolloError
+  loading?: boolean
+}
+
+const ConfirmAction = ({
+  children,
+  title,
+  description,
+  actionText,
+  onConfirm,
+  error,
+  loading,
+}: ConfirmActionProps) => {
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <ButtonWithLoader type="button" variant="destructive" loading={loading}>
+          {children}
+        </ButtonWithLoader>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          <div className="bg-red-400">{error?.message}</div>
+          <AlertDialogDescription>{description}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Annuleer</AlertDialogCancel>
+          <AlertDialogAction
+            className={buttonVariants({
+              variant: 'destructive',
+            })}
+            onClick={onConfirm}
+            disabled={loading}
+          >
+            {actionText || 'Bevestigen'}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}
+
+export default ConfirmAction

--- a/web/src/components/JobProfileCard/JobProfileCard.tsx
+++ b/web/src/components/JobProfileCard/JobProfileCard.tsx
@@ -1,6 +1,8 @@
 import { Car, Edit } from 'lucide-react'
 import { JobProfilesQuery } from 'types/graphql'
 
+import AddJobProfileModal from 'src/components/AddJobProfileModal'
+
 import { Badge } from '../ui/badge'
 import {
   Card,
@@ -20,7 +22,12 @@ const JobProfileCard = ({ item }: JobProfileCardProps) => {
     <Card key={item.id}>
       <CardHeader className="relative flex justify-between">
         <CardTitle className="w-4/5 break-words">{item.name}</CardTitle>
-        <Edit className="absolute right-4 top-4 text-muted-foreground hover:cursor-pointer hover:text-accent/70" />
+        <AddJobProfileModal
+          currentJobProfile={item}
+          trigger={
+            <Edit className="absolute right-4 top-4 text-muted-foreground hover:cursor-pointer hover:text-accent/70" />
+          }
+        />
       </CardHeader>
       <CardContent>
         <div className="-mt-2 flex flex-wrap items-center justify-between">


### PR DESCRIPTION
This PR makes it possible to edit job profiles. 

![image](https://github.com/user-attachments/assets/460fd995-627a-44b7-a59b-d6c8c290a61e)


Two notes:

1. I created a new component for confirmation dialog (ConfirmActionComponent), which can be used for similar cases. 
2. The modal component accepts `trigger` prop, which is an element for the trigger. In other implementations, we use `isEditing` to conditionally render elements. I think this approach of using trigger is better because it's explicit and avoids conditionals. If so, we want to change the `isEditing` use in other places.
