### PR TITLE
chore(vscode): Use non-relative import paths for modules

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,5 +16,6 @@
   ],
   "cSpell.words": [
     "Fleckz"
-  ]
+  ],
+  "typescript.preferences.importModuleSpecifier": "non-relative"
 }


### PR DESCRIPTION
This PR is a suggestion to use non-relative import paths for modules. 

For example, instead of doing:

```ts
import { Button } from '../ui/button'
```

it will be:

```ts
import { Button } from 'src/components/ui/button'
```

@jazellemaira what do you think?