### PR TITLE
chore(db): Use decimal values for currency [skip ci]

### DIFF
--- a/api/db/migrations/20241007165839_use_decimal_for_currency/migration.sql
+++ b/api/db/migrations/20241007165839_use_decimal_for_currency/migration.sql
@@ -1,0 +1,14 @@
+/*
+  Warnings:
+
+  - You are about to alter the column `hourlyWageMin` on the `JobProfile` table. The data in that column could be lost. The data in that column will be cast from `DoublePrecision` to `Decimal(65,30)`.
+  - You are about to alter the column `hourlyWageMax` on the `JobProfile` table. The data in that column could be lost. The data in that column will be cast from `DoublePrecision` to `Decimal(65,30)`.
+  - You are about to alter the column `kmAllowance` on the `JobProfile` table. The data in that column could be lost. The data in that column will be cast from `DoublePrecision` to `Decimal(65,30)`.
+  - You are about to alter the column `totalBudgetPerHour` on the `JobProfile` table. The data in that column could be lost. The data in that column will be cast from `DoublePrecision` to `Decimal(65,30)`.
+
+*/
+-- AlterTable
+ALTER TABLE "JobProfile" ALTER COLUMN "hourlyWageMin" SET DATA TYPE DECIMAL(65,30),
+ALTER COLUMN "hourlyWageMax" SET DATA TYPE DECIMAL(65,30),
+ALTER COLUMN "kmAllowance" SET DATA TYPE DECIMAL(65,30),
+ALTER COLUMN "totalBudgetPerHour" SET DATA TYPE DECIMAL(65,30);

--- a/api/db/schema.prisma
+++ b/api/db/schema.prisma
@@ -93,13 +93,13 @@ model JobProfile {
   name               String
   yearsOfExp         Int
   certificates       Certificate[]
-  hourlyWageMin      Float
-  hourlyWageMax      Float
+  hourlyWageMin      Decimal
+  hourlyWageMax      Decimal
   maxTravelDistance  Float?
   isTravelReimbursed Boolean?
   isCarAvailable     Boolean?
-  kmAllowance        Float?
-  totalBudgetPerHour Float?
+  kmAllowance        Decimal?
+  totalBudgetPerHour Decimal?
   comment            String?
   workRequest        WorkRequest[]
   createdBy          User?         @relation(fields: [userId], references: [id])


### PR DESCRIPTION
This PR converts the currency values in job profiles to decimal from float. 

Decimal values are less prone to rounding errors, and thus more suitable for currency values.

Fixes #132 