### PR TITLE
Show confirmation dialog to discard any edits

### DIFF
--- a/web/src/components/DiscardChangesAlert/DiscardChangesAlert.stories.tsx
+++ b/web/src/components/DiscardChangesAlert/DiscardChangesAlert.stories.tsx
@@ -1,0 +1,26 @@
+// Pass props to your component by passing an `args` object to your story
+//
+// ```tsx
+// export const Primary: Story = {
+//  args: {
+//    propName: propValue
+//  }
+// }
+// ```
+//
+// See https://storybook.js.org/docs/react/writing-stories/args.
+
+import type { Meta, StoryObj } from '@storybook/react'
+
+import DiscardChangesAlert from './DiscardChangesAlert'
+
+const meta: Meta<typeof DiscardChangesAlert> = {
+  component: DiscardChangesAlert,
+  tags: ['autodocs'],
+}
+
+export default meta
+
+type Story = StoryObj<typeof DiscardChangesAlert>
+
+export const Primary: Story = {}

--- a/web/src/components/DiscardChangesAlert/DiscardChangesAlert.test.tsx
+++ b/web/src/components/DiscardChangesAlert/DiscardChangesAlert.test.tsx
@@ -1,0 +1,20 @@
+import { render } from '@redwoodjs/testing/web'
+
+import DiscardChangesAlert from './DiscardChangesAlert'
+
+//   Improve this test with help from the Redwood Testing Doc:
+//    https://redwoodjs.com/docs/testing#testing-components
+
+describe('DiscardChangesAlert', () => {
+  it('renders successfully', () => {
+    expect(() => {
+      render(
+        <DiscardChangesAlert
+          open={false}
+          setOpen={() => {}}
+          onConfirm={() => {}}
+        />
+      )
+    }).not.toThrow()
+  })
+})

--- a/web/src/components/DiscardChangesAlert/DiscardChangesAlert.tsx
+++ b/web/src/components/DiscardChangesAlert/DiscardChangesAlert.tsx
@@ -1,0 +1,50 @@
+import { Dispatch, SetStateAction } from 'react'
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from 'src/components/ui/alert-dialog'
+
+type DiscardChangesAlertProps = {
+  open: boolean
+  setOpen: Dispatch<SetStateAction<boolean>>
+  onConfirm: () => void
+}
+
+const DiscardChangesAlert = ({
+  open,
+  setOpen,
+  onConfirm,
+}: DiscardChangesAlertProps) => {
+  function handleConfirm() {
+    setOpen(false)
+    onConfirm()
+  }
+  return (
+    <AlertDialog open={open} onOpenChange={() => setOpen(false)}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Ziet u ervan af?</AlertDialogTitle>
+          <AlertDialogDescription>
+            U heeft enkele wijzigingen aangebracht maar gaat nu weg van het
+            formulier.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Terug</AlertDialogCancel>
+          <AlertDialogAction onClick={handleConfirm}>
+            Verlies wijzigingen
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}
+
+export default DiscardChangesAlert

--- a/web/src/components/PlanWorkComponent/PlanWorkComponent.tsx
+++ b/web/src/components/PlanWorkComponent/PlanWorkComponent.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 
 import { zodResolver } from '@hookform/resolvers/zod'
 import { formatDate } from 'date-fns'
@@ -13,6 +13,7 @@ import { useMutation } from '@redwoodjs/web'
 import { toast } from '@redwoodjs/web/toast'
 
 import { useAuth } from 'src/auth'
+import DiscardChangesAlert from 'src/components/DiscardChangesAlert/DiscardChangesAlert'
 import SelectAddressCell from 'src/components/SelectAddressCell'
 import SelectJobProfileCell from 'src/components/SelectJobProfileCell'
 import { Button } from 'src/components/ui/button'
@@ -96,6 +97,7 @@ const PlanWorkComponent = ({
 }: PlanWorkComponentProps) => {
   const { currentUser } = useAuth()
   const isEditing = useMemo(() => !!defaultValues?.id, [defaultValues])
+  const [discardChangesOpen, setDiscardChangesOpen] = useState(false)
 
   const formSchema = z.object({
     id: z.string().cuid().optional(),
@@ -238,12 +240,19 @@ const PlanWorkComponent = ({
     }).finally(() => toast.dismiss(loadingToast))
   }
 
+  function handleOnOpenChange() {
+    if (form.formState.isDirty) {
+      return setDiscardChangesOpen(true)
+    }
+    setOpen((c) => !c)
+  }
+
   useEffect(() => {
     form.reset(currentDefaultValues)
   }, [form, currentDefaultValues])
 
   return (
-    <Dialog open={open} onOpenChange={() => setOpen((c) => !c)}>
+    <Dialog open={open} onOpenChange={handleOnOpenChange}>
       <DialogTrigger asChild>
         {!hideTrigger && (
           <Button
@@ -443,6 +452,11 @@ const PlanWorkComponent = ({
             </fieldset>
           </form>
         </Form>
+        <DiscardChangesAlert
+          open={discardChangesOpen}
+          setOpen={setDiscardChangesOpen}
+          onConfirm={() => setOpen(false)}
+        />
       </DialogContent>
     </Dialog>
   )


### PR DESCRIPTION
This PR adds a confirmation dialogue to confirm discarding any edits (if the form is dirty). This is only for the Plan Work component.

Let's open issues for other dialogs, if needed...


![image](https://github.com/user-attachments/assets/8e221f95-53ef-46a0-8a63-c66d2d365ede)


Fixes #68 