### PR TITLE
Moving the uitzendbureau page to the settings

### DIFF
--- a/web/src/Routes.tsx
+++ b/web/src/Routes.tsx
@@ -25,7 +25,6 @@ const Routes = () => {
           <Route path="/overview" page={OverviewPage} name="overview" />
           <Route path="/plan" page={PlanPage} name="plan" />
           <Route path="/job-profiles" page={JobProfilesPage} name="jobProfiles" />
-          <Route path="/temp-agencies" page={TempAgenciesPage} name="tempAgencies" />
           <Route path="/dashboard" page={DashboardPage} name="dashboard" />
         </Set>
         <Set wrap={WorkRequestPageLayout}>
@@ -35,6 +34,7 @@ const Routes = () => {
           <Route path="/settings" redirect="/settings/profile" />
           <Route path="/settings/profile" page={ProfilePage} name="profile" />
           <Route path="/settings/business" page={BusinessPage} name="business" />
+          <Route path="/temp-agencies" page={TempAgenciesPage} name="tempAgencies" />
         </Set>
       </PrivateSet>
       <Set wrap={DefaultLayout}>

--- a/web/src/components/Nav/Nav.tsx
+++ b/web/src/components/Nav/Nav.tsx
@@ -75,11 +75,6 @@ const Nav = ({ className }: NavProps) => {
             <Link to={routes.dashboard()}>Dashboard</Link>
           </NavigationMenuLink>
         </NavigationMenuItem>
-        <NavigationMenuItem>
-          <NavigationMenuLink asChild className={navigationMenuTriggerStyle()}>
-            <Link to={routes.tempAgencies()}>Uitzendbureau</Link>
-          </NavigationMenuLink>
-        </NavigationMenuItem>
       </NavigationMenuList>
       <NavigationMenuList className="mx-4 flex items-center">
         <DropdownMenu>

--- a/web/src/components/SideNav/SideNav.tsx
+++ b/web/src/components/SideNav/SideNav.tsx
@@ -1,4 +1,4 @@
-import { Building2, CreditCard, Earth, Settings, User } from 'lucide-react'
+import { BriefcaseBusiness, Building2, Settings, User } from 'lucide-react'
 
 import { Link, routes } from '@redwoodjs/router'
 
@@ -54,6 +54,16 @@ const SideNav = ({ className }: SideNavProps) => {
                 <h4 className="hidden text-left xs:block">Bedrijf</h4>
               </Link>
             </li>
+            <li className="w-full py-1 pl-1 xs:pl-0">
+              <Link
+                to={routes.tempAgencies()}
+                className="flex items-center gap-2 py-1 xs:px-2"
+              >
+                <BriefcaseBusiness className="size-5" />{' '}
+                <h4 className="hidden text-left xs:block">Uitzendbureaus</h4>
+              </Link>
+            </li>
+
             {/* TODO: Bring this back when we need billing information */}
             {/* <li className="w-full py-1 pl-1 xs:pl-0">
               <Link

--- a/web/src/pages/TempAgenciesPage/TempAgenciesPage.tsx
+++ b/web/src/pages/TempAgenciesPage/TempAgenciesPage.tsx
@@ -11,7 +11,7 @@ const TempAgenciesPage = () => {
     <>
       <Metadata title="TempAgencies" description="TempAgencies page" />
       <div className="mx-auto flex max-w-4xl flex-col">
-        <h1 className="text-xl font-bold text-white/90">Uitzendbureau</h1>
+        <h1 className="text-xl font-bold text-white/90">Uitzendbureaus</h1>
         <div className="mx-auto flex w-full max-w-4xl flex-col items-center gap-4 pt-4">
           <TempAgenciesCell />
           <AddTempAgencyDialog


### PR DESCRIPTION
This PR moves the uitzendbureau page to the settings set. 

We still don't have role-based access control yet, so the page is accessible by all the users. 

We need to restrict access to this page only for admins and intermediaries. I created an issue here to continue working on this:  https://github.com/fleckz-nl/fleckz/issues/262


Fixes #237 