### PR TITLE
feat(address): Restrict address search to their own

### DIFF
--- a/api/src/services/addresses/addresses.ts
+++ b/api/src/services/addresses/addresses.ts
@@ -7,7 +7,17 @@ import type {
 import { db } from 'src/lib/db'
 
 export const addresses: QueryResolvers['addresses'] = () => {
-  return db.address.findMany()
+  const userRoles = context.currentUser.roles
+  if (userRoles.includes('ADMIN') || userRoles.includes('MEDIATOR'))
+    return db.address.findMany()
+
+  return db.address.findMany({
+    where: {
+      workplace: {
+        some: { clientBusiness: { createdBy: { id: context.currentUser.id } } },
+      },
+    },
+  })
 }
 
 export const address: QueryResolvers['address'] = ({ id }) => {


### PR DESCRIPTION
This PR only shows addresses for the businesses created by the users (client).

This rule does not apply to admins and mediators. They still see all the addresses. 

Fixes #260 