### PR TITLE
Creating shift confirmation drawer

### DIFF
--- a/web/src/components/ShiftConfirmationDrawer/ShiftConfirmationDrawer.stories.tsx
+++ b/web/src/components/ShiftConfirmationDrawer/ShiftConfirmationDrawer.stories.tsx
@@ -1,0 +1,26 @@
+// Pass props to your component by passing an `args` object to your story
+//
+// ```tsx
+// export const Primary: Story = {
+//  args: {
+//    propName: propValue
+//  }
+// }
+// ```
+//
+// See https://storybook.js.org/docs/react/writing-stories/args.
+
+import type { Meta, StoryObj } from '@storybook/react'
+
+import ShiftConfirmationDrawer from './ShiftConfirmationDrawer'
+
+const meta: Meta<typeof ShiftConfirmationDrawer> = {
+  component: ShiftConfirmationDrawer,
+  tags: ['autodocs'],
+}
+
+export default meta
+
+type Story = StoryObj<typeof ShiftConfirmationDrawer>
+
+export const Primary: Story = {}

--- a/web/src/components/ShiftConfirmationDrawer/ShiftConfirmationDrawer.stories.tsx
+++ b/web/src/components/ShiftConfirmationDrawer/ShiftConfirmationDrawer.stories.tsx
@@ -11,6 +11,7 @@
 // See https://storybook.js.org/docs/react/writing-stories/args.
 
 import type { Meta, StoryObj } from '@storybook/react'
+import { format } from 'date-fns'
 
 import ShiftConfirmationDrawer from './ShiftConfirmationDrawer'
 
@@ -23,4 +24,8 @@ export default meta
 
 type Story = StoryObj<typeof ShiftConfirmationDrawer>
 
-export const Primary: Story = {}
+export const Primary: Story = {
+  args: {
+    time: format(new Date(), 'HH:mm'),
+  },
+}

--- a/web/src/components/ShiftConfirmationDrawer/ShiftConfirmationDrawer.test.tsx
+++ b/web/src/components/ShiftConfirmationDrawer/ShiftConfirmationDrawer.test.tsx
@@ -1,0 +1,14 @@
+import { render } from '@redwoodjs/testing/web'
+
+import ShiftConfirmationDrawer from './ShiftConfirmationDrawer'
+
+//   Improve this test with help from the Redwood Testing Doc:
+//    https://redwoodjs.com/docs/testing#testing-components
+
+describe('ShiftConfirmationDrawer', () => {
+  it('renders successfully', () => {
+    expect(() => {
+      render(<ShiftConfirmationDrawer />)
+    }).not.toThrow()
+  })
+})

--- a/web/src/components/ShiftConfirmationDrawer/ShiftConfirmationDrawer.tsx
+++ b/web/src/components/ShiftConfirmationDrawer/ShiftConfirmationDrawer.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 
+import { ThumbsDown, ThumbsUp } from 'lucide-react'
 import { Button } from 'web/src/components/ui/button'
 import {
   Drawer,
@@ -68,12 +69,14 @@ const ShiftConfirmationDrawer = ({ time }: ShiftConfirmationDrawerProps) => {
               <div>
                 <h3 className="flex flex-wrap items-center justify-between">
                   <TempAgencyWorker />
-            <div className="flex flex-col">
-              <h3 className="flex items-center justify-between">
-                <TempAgencyWorker />
-                <Button className="bg-black text-accent">Nu</Button>
-              </h3>
-              <TimePicker time={time} />
+                  <div className="flex gap-2">
+                    <Button className="bg-gray-900 p-2 text-accent">
+                      <ThumbsUp className="size-5" />
+                    </Button>
+                    <Button className="bg-gray-900 p-2 text-accent">
+                      <ThumbsDown className="size-5" />
+                    </Button>
+                  </div>
                 </h3>
                 <div className="my-4 flex flex-col items-center">
                   <span className="mx-auto text-xl text-muted/50">

--- a/web/src/components/ShiftConfirmationDrawer/ShiftConfirmationDrawer.tsx
+++ b/web/src/components/ShiftConfirmationDrawer/ShiftConfirmationDrawer.tsx
@@ -25,7 +25,7 @@ type ShiftConfirmationDrawerProps = {
 const ShiftConfirmationDrawer = ({ time }: ShiftConfirmationDrawerProps) => {
   return (
     <Drawer>
-      <DrawerTrigger>
+      <DrawerTrigger asChild>
         <Button className="bg-accent/80 text-black hover:bg-accent hover:text-black">
           Inchecken: Nu
         </Button>

--- a/web/src/components/ShiftConfirmationDrawer/ShiftConfirmationDrawer.tsx
+++ b/web/src/components/ShiftConfirmationDrawer/ShiftConfirmationDrawer.tsx
@@ -14,7 +14,11 @@ import {
   TabsTrigger,
 } from 'web/src/components/ui/tabs'
 
-const ShiftConfirmationDrawer = () => {
+type ShiftConfirmationDrawerProps = {
+  time: string
+}
+
+const ShiftConfirmationDrawer = ({ time }: ShiftConfirmationDrawerProps) => {
   return (
     <Drawer>
       <DrawerTrigger>
@@ -61,6 +65,7 @@ const ShiftConfirmationDrawer = () => {
               <span className="mx-auto text-2xl text-white">DD MMM YYYY</span>
               <input
                 type="time"
+                value={time}
                 className="rounded-sm bg-white px-2 text-center text-2xl text-primary"
               />
             </div>

--- a/web/src/components/ShiftConfirmationDrawer/ShiftConfirmationDrawer.tsx
+++ b/web/src/components/ShiftConfirmationDrawer/ShiftConfirmationDrawer.tsx
@@ -69,7 +69,7 @@ const ShiftConfirmationDrawer = ({ time }: ShiftConfirmationDrawerProps) => {
                 </h3>
                 <TimePicker time={time} />
               </div>
-              <Button className="bg-accent/80 text-black hover:bg-accent hover:text-black">
+              <Button className="bg-accent/80 text-black hover:bg-accent hover:text-black sm:mx-auto">
                 Bevestingen
               </Button>
             </div>
@@ -91,7 +91,7 @@ const ShiftConfirmationDrawer = ({ time }: ShiftConfirmationDrawerProps) => {
                 </h3>
                 <TimePicker time={time} />
               </div>
-              <Button className="bg-accent/80 text-black hover:bg-accent hover:text-black">
+              <Button className="bg-accent/80 text-black hover:bg-accent hover:text-black sm:mx-auto">
                 Bevestingen
               </Button>
             </div>
@@ -136,7 +136,7 @@ const ShiftConfirmationDrawer = ({ time }: ShiftConfirmationDrawerProps) => {
                   </div>
                 </div>
               </div>
-              <Button className="bg-accent/80 text-black hover:bg-accent hover:text-black">
+              <Button className="bg-accent/80 text-black hover:bg-accent hover:text-black sm:mx-auto">
                 Bevestingen
               </Button>
             </div>

--- a/web/src/components/ShiftConfirmationDrawer/ShiftConfirmationDrawer.tsx
+++ b/web/src/components/ShiftConfirmationDrawer/ShiftConfirmationDrawer.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react'
+const ShiftConfirmationDrawer = () => {
+  return (
+    <div>
+      <h2>{'ShiftConfirmationDrawer'}</h2>
+      <p>
+        {
+          'Find me in ./web/src/components/ShiftConfirmationDrawer/ShiftConfirmationDrawer.tsx'
+        }
+      </p>
+    </div>
+  )
+}
+
+export default ShiftConfirmationDrawer

--- a/web/src/components/ShiftConfirmationDrawer/ShiftConfirmationDrawer.tsx
+++ b/web/src/components/ShiftConfirmationDrawer/ShiftConfirmationDrawer.tsx
@@ -90,6 +90,14 @@ const ShiftConfirmationDrawer = ({ time }: ShiftConfirmationDrawerProps) => {
                   <Button className="bg-gray-900 text-accent">Nu</Button>
                 </h3>
                 <TimePicker time={time} />
+                <div className="flex gap-2 self-end">
+                  <Button className="bg-gray-900 p-2 text-accent">
+                    <ThumbsUp className="size-5" />
+                  </Button>
+                  <Button className="bg-gray-900 p-2 text-accent">
+                    <ThumbsDown className="size-5" />
+                  </Button>
+                </div>
               </div>
               <Button className="bg-accent/80 text-black hover:bg-accent hover:text-black sm:mx-auto">
                 Bevestingen

--- a/web/src/components/ShiftConfirmationDrawer/ShiftConfirmationDrawer.tsx
+++ b/web/src/components/ShiftConfirmationDrawer/ShiftConfirmationDrawer.tsx
@@ -53,26 +53,49 @@ const ShiftConfirmationDrawer = ({ time }: ShiftConfirmationDrawerProps) => {
             </TabsTrigger>
           </TabsList>
           <TabsContent value="shiftCheckIn">
+            <div className="my-4 flex h-[250px] flex-col justify-between">
+              <div className="flex flex-col">
+                <h3 className="flex flex-wrap items-center justify-between">
+                  <div className="flex gap-4">
+                    <TempAgencyWorker />
                     <Badge
                       variant="outline"
                       className=" h-4 bg-lime-500 text-black"
                     >
                       In
                     </Badge>
+                  </div>
                   <Button className="bg-gray-900 text-accent">Nu</Button>
+                </h3>
+                <TimePicker time={time} />
+              </div>
               <Button className="bg-accent/80 text-black hover:bg-accent hover:text-black">
                 Bevestingen
               </Button>
             </div>
           </TabsContent>
           <TabsContent value="shiftCheckOut">
+            <div className="my-4 flex h-[250px] flex-col justify-between">
+              <div className="flex flex-col">
+                <h3 className="flex flex-wrap items-center justify-between">
+                  <div className="flex gap-4">
+                    <TempAgencyWorker />
                     <Badge
                       variant="outline"
                       className=" h-4 bg-red-500 text-black"
                     >
                       Uit
                     </Badge>
+                  </div>
                   <Button className="bg-gray-900 text-accent">Nu</Button>
+                </h3>
+                <TimePicker time={time} />
+              </div>
+              <Button className="bg-accent/80 text-black hover:bg-accent hover:text-black">
+                Bevestingen
+              </Button>
+            </div>
+          </TabsContent>
           <TabsContent value="shiftSummary">
             <div className="my-4 flex h-[250px] flex-col justify-between">
               <div>

--- a/web/src/components/ShiftConfirmationDrawer/ShiftConfirmationDrawer.tsx
+++ b/web/src/components/ShiftConfirmationDrawer/ShiftConfirmationDrawer.tsx
@@ -67,7 +67,7 @@ const ShiftConfirmationDrawer = ({ time }: ShiftConfirmationDrawerProps) => {
               </span>
               <input
                 type="time"
-                value={time}
+                defaultValue={time}
                 className="rounded-sm bg-white px-2 text-center text-3xl text-primary"
               />
             </div>

--- a/web/src/components/ShiftConfirmationDrawer/ShiftConfirmationDrawer.tsx
+++ b/web/src/components/ShiftConfirmationDrawer/ShiftConfirmationDrawer.tsx
@@ -62,11 +62,13 @@ const ShiftConfirmationDrawer = ({ time }: ShiftConfirmationDrawerProps) => {
               <Button className="bg-black text-accent">Nu</Button>
             </h3>
             <div className="mx-auto flex items-center justify-center gap-5 py-10">
-              <span className="mx-auto text-2xl text-white">DD MMM YYYY</span>
+              <span className="mx-auto text-2xl text-muted/50">
+                12 Okt 2024
+              </span>
               <input
                 type="time"
                 value={time}
-                className="rounded-sm bg-white px-2 text-center text-2xl text-primary"
+                className="rounded-sm bg-white px-2 text-center text-3xl text-primary"
               />
             </div>
             <Button className="bg-accent/80 text-black hover:bg-accent hover:text-black">

--- a/web/src/components/ShiftConfirmationDrawer/ShiftConfirmationDrawer.tsx
+++ b/web/src/components/ShiftConfirmationDrawer/ShiftConfirmationDrawer.tsx
@@ -30,7 +30,7 @@ const ShiftConfirmationDrawer = ({ time }: ShiftConfirmationDrawerProps) => {
           Inchecken: Nu
         </Button>
       </DrawerTrigger>
-      <DrawerContent className="container border-secondary/10 bg-gray-950 px-4 text-white/70">
+      <DrawerContent className="container max-w-lg border-secondary/10 bg-gray-950 px-4 text-white/70">
         <Tabs defaultValue="shiftCheckIn">
           <TabsList className="mx-auto mt-2 grid grid-cols-3 gap-2">
             <TabsTrigger

--- a/web/src/components/ShiftConfirmationDrawer/ShiftConfirmationDrawer.tsx
+++ b/web/src/components/ShiftConfirmationDrawer/ShiftConfirmationDrawer.tsx
@@ -63,12 +63,44 @@ const ShiftConfirmationDrawer = ({ time }: ShiftConfirmationDrawerProps) => {
             </div>
           </TabsContent>
           <TabsContent value="shiftCheckOut">
+          <TabsContent value="shiftSummary">
+            <div className="my-4 flex h-[250px] flex-col justify-between">
+              <div>
+                <h3 className="flex flex-wrap items-center justify-between">
+                  <TempAgencyWorker />
             <div className="flex flex-col">
               <h3 className="flex items-center justify-between">
                 <TempAgencyWorker />
                 <Button className="bg-black text-accent">Nu</Button>
               </h3>
               <TimePicker time={time} />
+                </h3>
+                <div className="my-4 flex flex-col items-center">
+                  <span className="mx-auto text-xl text-muted/50">
+                    12 Okt 2024
+                  </span>
+                  <div className="container my-4 grid grid-cols-3 place-items-center gap-20 xs:gap-0">
+                    <div className="center flex-col">
+                      <span className="font-extralight text-white/50">
+                        Inchecken
+                      </span>
+                      <span className="text-3xl">00:00</span>
+                    </div>
+                    <div className="center flex-col">
+                      <span className="text-4xl font-semibold">5:24</span>
+                      <span className="font-extralight text-white/50">
+                        uren
+                      </span>
+                    </div>
+                    <div className="center flex-col">
+                      <span className="font-extralight text-white/50">
+                        Uitchecken
+                      </span>
+                      <span className="text-3xl">00:00</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
               <Button className="bg-accent/80 text-black hover:bg-accent hover:text-black">
                 Bevestingen
               </Button>

--- a/web/src/components/ShiftConfirmationDrawer/ShiftConfirmationDrawer.tsx
+++ b/web/src/components/ShiftConfirmationDrawer/ShiftConfirmationDrawer.tsx
@@ -16,6 +16,7 @@ import {
 
 import TempAgencyWorker from 'src/components/TempAgencyWorker'
 import TimePicker from 'src/components/TimePicker'
+import { Badge } from 'src/components/ui/badge'
 
 type ShiftConfirmationDrawerProps = {
   time: string
@@ -52,18 +53,24 @@ const ShiftConfirmationDrawer = ({ time }: ShiftConfirmationDrawerProps) => {
             </TabsTrigger>
           </TabsList>
           <TabsContent value="shiftCheckIn">
-            <div className="flex flex-col">
-              <h3 className="flex items-center justify-between">
-                <TempAgencyWorker />
-                <Button className="bg-black text-accent">Nu</Button>
-              </h3>
-              <TimePicker time={time} />
+                    <Badge
+                      variant="outline"
+                      className=" h-4 bg-lime-500 text-black"
+                    >
+                      In
+                    </Badge>
               <Button className="bg-accent/80 text-black hover:bg-accent hover:text-black">
                 Bevestingen
               </Button>
             </div>
           </TabsContent>
           <TabsContent value="shiftCheckOut">
+                    <Badge
+                      variant="outline"
+                      className=" h-4 bg-red-500 text-black"
+                    >
+                      Uit
+                    </Badge>
           <TabsContent value="shiftSummary">
             <div className="my-4 flex h-[250px] flex-col justify-between">
               <div>

--- a/web/src/components/ShiftConfirmationDrawer/ShiftConfirmationDrawer.tsx
+++ b/web/src/components/ShiftConfirmationDrawer/ShiftConfirmationDrawer.tsx
@@ -50,18 +50,29 @@ const ShiftConfirmationDrawer = ({ time }: ShiftConfirmationDrawerProps) => {
               Samenvatting
             </TabsTrigger>
           </TabsList>
-          <TabsContent
-            value="shiftCheckIn"
-            className="flex w-full flex-col pb-4"
-          >
-            <h3 className="flex items-center justify-between">
-              <TempAgencyWorker />
-              <Button className="bg-black text-accent">Nu</Button>
-            </h3>
-            <TimePicker time={time} />
-            <Button className="bg-accent/80 text-black hover:bg-accent hover:text-black">
-              Bevestingen
-            </Button>
+          <TabsContent value="shiftCheckIn">
+            <div className="flex flex-col">
+              <h3 className="flex items-center justify-between">
+                <TempAgencyWorker />
+                <Button className="bg-black text-accent">Nu</Button>
+              </h3>
+              <TimePicker time={time} />
+              <Button className="bg-accent/80 text-black hover:bg-accent hover:text-black">
+                Bevestingen
+              </Button>
+            </div>
+          </TabsContent>
+          <TabsContent value="shiftCheckOut">
+            <div className="flex flex-col">
+              <h3 className="flex items-center justify-between">
+                <TempAgencyWorker />
+                <Button className="bg-black text-accent">Nu</Button>
+              </h3>
+              <TimePicker time={time} />
+              <Button className="bg-accent/80 text-black hover:bg-accent hover:text-black">
+                Bevestingen
+              </Button>
+            </div>
           </TabsContent>
         </Tabs>
       </DrawerContent>

--- a/web/src/components/ShiftConfirmationDrawer/ShiftConfirmationDrawer.tsx
+++ b/web/src/components/ShiftConfirmationDrawer/ShiftConfirmationDrawer.tsx
@@ -30,7 +30,7 @@ const ShiftConfirmationDrawer = ({ time }: ShiftConfirmationDrawerProps) => {
           Inchecken: Nu
         </Button>
       </DrawerTrigger>
-      <DrawerContent className="container max-w-lg border-secondary/10 bg-gray-950 px-4 text-white/70">
+      <DrawerContent className="container max-w-lg border-secondary/10 bg-gray-950 px-6 text-white/70">
         <Tabs defaultValue="shiftCheckIn">
           <TabsList className="mx-auto mt-2 grid grid-cols-3 gap-2">
             <TabsTrigger

--- a/web/src/components/ShiftConfirmationDrawer/ShiftConfirmationDrawer.tsx
+++ b/web/src/components/ShiftConfirmationDrawer/ShiftConfirmationDrawer.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 
-import { Badge } from 'web/src/components/ui/badge'
 import { Button } from 'web/src/components/ui/button'
 import {
   Drawer,
@@ -13,6 +12,8 @@ import {
   TabsList,
   TabsTrigger,
 } from 'web/src/components/ui/tabs'
+
+import TempAgencyWorker from 'src/components/TempAgencyWorker'
 
 type ShiftConfirmationDrawerProps = {
   time: string
@@ -53,12 +54,7 @@ const ShiftConfirmationDrawer = ({ time }: ShiftConfirmationDrawerProps) => {
             className="flex w-full flex-col pb-4"
           >
             <h3 className="flex items-center justify-between">
-              <div className="flex flex-col">
-                <span className="font-semibold">Achternaam Voornaam</span>
-                <Badge className="w-fit bg-black text-primary-foreground/50">
-                  Uitzendbureau
-                </Badge>
-              </div>
+              <TempAgencyWorker />
               <Button className="bg-black text-accent">Nu</Button>
             </h3>
             <div className="mx-auto flex items-center justify-center gap-5 py-10">

--- a/web/src/components/ShiftConfirmationDrawer/ShiftConfirmationDrawer.tsx
+++ b/web/src/components/ShiftConfirmationDrawer/ShiftConfirmationDrawer.tsx
@@ -1,10 +1,19 @@
 import * as React from 'react'
+
+import { Badge } from 'web/src/components/ui/badge'
 import { Button } from 'web/src/components/ui/button'
 import {
   Drawer,
   DrawerContent,
   DrawerTrigger,
 } from 'web/src/components/ui/drawer'
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from 'web/src/components/ui/tabs'
+
 const ShiftConfirmationDrawer = () => {
   return (
     <Drawer>
@@ -12,6 +21,32 @@ const ShiftConfirmationDrawer = () => {
         <Button>Inchecken: Nu</Button>
       </DrawerTrigger>
       <DrawerContent className="container px-4">
+        <Tabs defaultValue="shiftCheckIn">
+          <TabsList className="mx-auto mt-2 grid grid-cols-3 gap-2">
+            <TabsTrigger value="shiftCheckIn">Inchecken</TabsTrigger>
+            <TabsTrigger value="shiftCheckOut">Uitchecken</TabsTrigger>
+            <TabsTrigger value="shiftSummary">Samenvatting</TabsTrigger>
+          </TabsList>
+          <TabsContent
+            value="shiftCheckIn"
+            className="flex w-full flex-col pb-4"
+          >
+            <h3 className="flex items-center justify-between">
+              <div className="flex flex-col">
+                <span className="font-semibold">Achternaam Voornaam</span>
+                <Badge className="w-fit">Uitzendbureau</Badge>
+              </div>
+              <Button>Nu</Button>
+            </h3>
+            <div className="mx-auto flex items-center justify-center gap-5 py-10">
+              <span className="mx-auto text-2xl">DD MMM YYYY</span>
+              <input
+                type="time"
+                className="rounded-sm bg-black px-2 text-center text-2xl text-white"
+              />
+            </div>
+          </TabsContent>
+        </Tabs>
       </DrawerContent>
     </Drawer>
   )

--- a/web/src/components/ShiftConfirmationDrawer/ShiftConfirmationDrawer.tsx
+++ b/web/src/components/ShiftConfirmationDrawer/ShiftConfirmationDrawer.tsx
@@ -18,14 +18,31 @@ const ShiftConfirmationDrawer = () => {
   return (
     <Drawer>
       <DrawerTrigger>
-        <Button>Inchecken: Nu</Button>
+        <Button className="bg-accent/80 text-black hover:bg-accent hover:text-black">
+          Inchecken: Nu
+        </Button>
       </DrawerTrigger>
-      <DrawerContent className="container px-4">
+      <DrawerContent className="container border-secondary/10 bg-gray-950 px-4 text-white/70">
         <Tabs defaultValue="shiftCheckIn">
           <TabsList className="mx-auto mt-2 grid grid-cols-3 gap-2">
-            <TabsTrigger value="shiftCheckIn">Inchecken</TabsTrigger>
-            <TabsTrigger value="shiftCheckOut">Uitchecken</TabsTrigger>
-            <TabsTrigger value="shiftSummary">Samenvatting</TabsTrigger>
+            <TabsTrigger
+              value="shiftCheckIn"
+              className="text-primary-foreground/30 data-[state=active]:bg-black/30 data-[state=active]:text-secondary"
+            >
+              Inchecken
+            </TabsTrigger>
+            <TabsTrigger
+              value="shiftCheckOut"
+              className=" text-primary-foreground/30 data-[state=active]:bg-black/30 data-[state=active]:text-secondary"
+            >
+              Uitchecken
+            </TabsTrigger>
+            <TabsTrigger
+              value="shiftSummary"
+              className="text-primary-foreground/30 data-[state=active]:bg-black/30 data-[state=active]:text-secondary"
+            >
+              Samenvatting
+            </TabsTrigger>
           </TabsList>
           <TabsContent
             value="shiftCheckIn"
@@ -34,18 +51,22 @@ const ShiftConfirmationDrawer = () => {
             <h3 className="flex items-center justify-between">
               <div className="flex flex-col">
                 <span className="font-semibold">Achternaam Voornaam</span>
-                <Badge className="w-fit">Uitzendbureau</Badge>
+                <Badge className="w-fit bg-black text-primary-foreground/50">
+                  Uitzendbureau
+                </Badge>
               </div>
-              <Button>Nu</Button>
+              <Button className="bg-black text-accent">Nu</Button>
             </h3>
             <div className="mx-auto flex items-center justify-center gap-5 py-10">
-              <span className="mx-auto text-2xl">DD MMM YYYY</span>
+              <span className="mx-auto text-2xl text-white">DD MMM YYYY</span>
               <input
                 type="time"
-                className="rounded-sm bg-black px-2 text-center text-2xl text-white"
+                className="rounded-sm bg-white px-2 text-center text-2xl text-primary"
               />
             </div>
-            <Button>Bevestingen</Button>
+            <Button className="bg-accent/80 text-black hover:bg-accent hover:text-black">
+              Bevestingen
+            </Button>
           </TabsContent>
         </Tabs>
       </DrawerContent>

--- a/web/src/components/ShiftConfirmationDrawer/ShiftConfirmationDrawer.tsx
+++ b/web/src/components/ShiftConfirmationDrawer/ShiftConfirmationDrawer.tsx
@@ -122,7 +122,7 @@ const ShiftConfirmationDrawer = ({ time }: ShiftConfirmationDrawerProps) => {
                   <span className="mx-auto text-xl text-muted/50">
                     12 Okt 2024
                   </span>
-                  <div className="container my-4 grid grid-cols-3 place-items-center gap-20 xs:gap-0">
+                  <div className="container my-4 grid grid-cols-3 place-items-center gap-20 text-white/80 xs:gap-0">
                     <div className="center flex-col">
                       <span className="font-extralight text-white/50">
                         Inchecken
@@ -130,7 +130,7 @@ const ShiftConfirmationDrawer = ({ time }: ShiftConfirmationDrawerProps) => {
                       <span className="text-3xl">00:00</span>
                     </div>
                     <div className="center flex-col">
-                      <span className="text-4xl font-semibold">5:24</span>
+                      <span className="font-semibol text-4xl">5:24</span>
                       <span className="font-extralight text-white/50">
                         uren
                       </span>

--- a/web/src/components/ShiftConfirmationDrawer/ShiftConfirmationDrawer.tsx
+++ b/web/src/components/ShiftConfirmationDrawer/ShiftConfirmationDrawer.tsx
@@ -14,6 +14,7 @@ import {
 } from 'web/src/components/ui/tabs'
 
 import TempAgencyWorker from 'src/components/TempAgencyWorker'
+import TimePicker from 'src/components/TimePicker'
 
 type ShiftConfirmationDrawerProps = {
   time: string
@@ -57,16 +58,7 @@ const ShiftConfirmationDrawer = ({ time }: ShiftConfirmationDrawerProps) => {
               <TempAgencyWorker />
               <Button className="bg-black text-accent">Nu</Button>
             </h3>
-            <div className="mx-auto flex items-center justify-center gap-5 py-10">
-              <span className="mx-auto text-2xl text-muted/50">
-                12 Okt 2024
-              </span>
-              <input
-                type="time"
-                defaultValue={time}
-                className="rounded-sm bg-white px-2 text-center text-3xl text-primary"
-              />
-            </div>
+            <TimePicker time={time} />
             <Button className="bg-accent/80 text-black hover:bg-accent hover:text-black">
               Bevestingen
             </Button>

--- a/web/src/components/ShiftConfirmationDrawer/ShiftConfirmationDrawer.tsx
+++ b/web/src/components/ShiftConfirmationDrawer/ShiftConfirmationDrawer.tsx
@@ -45,6 +45,7 @@ const ShiftConfirmationDrawer = () => {
                 className="rounded-sm bg-black px-2 text-center text-2xl text-white"
               />
             </div>
+            <Button>Bevestingen</Button>
           </TabsContent>
         </Tabs>
       </DrawerContent>

--- a/web/src/components/ShiftConfirmationDrawer/ShiftConfirmationDrawer.tsx
+++ b/web/src/components/ShiftConfirmationDrawer/ShiftConfirmationDrawer.tsx
@@ -109,14 +109,6 @@ const ShiftConfirmationDrawer = ({ time }: ShiftConfirmationDrawerProps) => {
               <div>
                 <h3 className="flex flex-wrap items-center justify-between">
                   <TempAgencyWorker />
-                  <div className="flex gap-2">
-                    <Button className="bg-gray-900 p-2 text-accent">
-                      <ThumbsUp className="size-5" />
-                    </Button>
-                    <Button className="bg-gray-900 p-2 text-accent">
-                      <ThumbsDown className="size-5" />
-                    </Button>
-                  </div>
                 </h3>
                 <div className="my-4 flex flex-col items-center">
                   <span className="mx-auto text-xl text-muted/50">

--- a/web/src/components/ShiftConfirmationDrawer/ShiftConfirmationDrawer.tsx
+++ b/web/src/components/ShiftConfirmationDrawer/ShiftConfirmationDrawer.tsx
@@ -1,14 +1,19 @@
 import * as React from 'react'
+import { Button } from 'web/src/components/ui/button'
+import {
+  Drawer,
+  DrawerContent,
+  DrawerTrigger,
+} from 'web/src/components/ui/drawer'
 const ShiftConfirmationDrawer = () => {
   return (
-    <div>
-      <h2>{'ShiftConfirmationDrawer'}</h2>
-      <p>
-        {
-          'Find me in ./web/src/components/ShiftConfirmationDrawer/ShiftConfirmationDrawer.tsx'
-        }
-      </p>
-    </div>
+    <Drawer>
+      <DrawerTrigger>
+        <Button>Inchecken: Nu</Button>
+      </DrawerTrigger>
+      <DrawerContent className="container px-4">
+      </DrawerContent>
+    </Drawer>
   )
 }
 

--- a/web/src/components/ShiftConfirmationDrawer/ShiftConfirmationDrawer.tsx
+++ b/web/src/components/ShiftConfirmationDrawer/ShiftConfirmationDrawer.tsx
@@ -59,6 +59,7 @@ const ShiftConfirmationDrawer = ({ time }: ShiftConfirmationDrawerProps) => {
                     >
                       In
                     </Badge>
+                  <Button className="bg-gray-900 text-accent">Nu</Button>
               <Button className="bg-accent/80 text-black hover:bg-accent hover:text-black">
                 Bevestingen
               </Button>
@@ -71,6 +72,7 @@ const ShiftConfirmationDrawer = ({ time }: ShiftConfirmationDrawerProps) => {
                     >
                       Uit
                     </Badge>
+                  <Button className="bg-gray-900 text-accent">Nu</Button>
           <TabsContent value="shiftSummary">
             <div className="my-4 flex h-[250px] flex-col justify-between">
               <div>

--- a/web/src/components/TempAgencyWorker/TempAgencyWorker.stories.tsx
+++ b/web/src/components/TempAgencyWorker/TempAgencyWorker.stories.tsx
@@ -1,0 +1,26 @@
+// Pass props to your component by passing an `args` object to your story
+//
+// ```tsx
+// export const Primary: Story = {
+//  args: {
+//    propName: propValue
+//  }
+// }
+// ```
+//
+// See https://storybook.js.org/docs/react/writing-stories/args.
+
+import type { Meta, StoryObj } from '@storybook/react'
+
+import TempAgencyWorker from './TempAgencyWorker'
+
+const meta: Meta<typeof TempAgencyWorker> = {
+  component: TempAgencyWorker,
+  tags: ['autodocs'],
+}
+
+export default meta
+
+type Story = StoryObj<typeof TempAgencyWorker>
+
+export const Primary: Story = {}

--- a/web/src/components/TempAgencyWorker/TempAgencyWorker.test.tsx
+++ b/web/src/components/TempAgencyWorker/TempAgencyWorker.test.tsx
@@ -1,0 +1,14 @@
+import { render } from '@redwoodjs/testing/web'
+
+import TempAgencyWorker from './TempAgencyWorker'
+
+//   Improve this test with help from the Redwood Testing Doc:
+//    https://redwoodjs.com/docs/testing#testing-components
+
+describe('TempAgencyWorker', () => {
+  it('renders successfully', () => {
+    expect(() => {
+      render(<TempAgencyWorker />)
+    }).not.toThrow()
+  })
+})

--- a/web/src/components/TempAgencyWorker/TempAgencyWorker.tsx
+++ b/web/src/components/TempAgencyWorker/TempAgencyWorker.tsx
@@ -1,0 +1,14 @@
+const TempAgencyWorker = () => {
+  return (
+    <div>
+      <h2>{'TempAgencyWorker'}</h2>
+      <p>
+        {
+          'Find me in ./web/src/components/TempAgencyWorker/TempAgencyWorker.tsx'
+        }
+      </p>
+    </div>
+  )
+}
+
+export default TempAgencyWorker

--- a/web/src/components/TempAgencyWorker/TempAgencyWorker.tsx
+++ b/web/src/components/TempAgencyWorker/TempAgencyWorker.tsx
@@ -1,12 +1,20 @@
-const TempAgencyWorker = () => {
+import * as React from 'react'
+
+import { Badge } from 'web/src/components/ui/badge'
+
+import { cn } from 'src/lib/utils'
+
+type TempAgencyWorkerProps = {
+  className?: string
+}
+
+const TempAgencyWorker = ({ className }: TempAgencyWorkerProps) => {
   return (
-    <div>
-      <h2>{'TempAgencyWorker'}</h2>
-      <p>
-        {
-          'Find me in ./web/src/components/TempAgencyWorker/TempAgencyWorker.tsx'
-        }
-      </p>
+    <div className={cn('flex flex-col', className)}>
+      <span className="font-semibold">Achternaam Voornaam</span>
+      <Badge className="w-fit bg-black text-primary-foreground/50">
+        Uitzendbureau
+      </Badge>
     </div>
   )
 }

--- a/web/src/components/TimePicker/TimePicker.stories.tsx
+++ b/web/src/components/TimePicker/TimePicker.stories.tsx
@@ -1,0 +1,26 @@
+// Pass props to your component by passing an `args` object to your story
+//
+// ```tsx
+// export const Primary: Story = {
+//  args: {
+//    propName: propValue
+//  }
+// }
+// ```
+//
+// See https://storybook.js.org/docs/react/writing-stories/args.
+
+import type { Meta, StoryObj } from '@storybook/react'
+
+import TimePicker from './TimePicker'
+
+const meta: Meta<typeof TimePicker> = {
+  component: TimePicker,
+  tags: ['autodocs'],
+}
+
+export default meta
+
+type Story = StoryObj<typeof TimePicker>
+
+export const Primary: Story = {}

--- a/web/src/components/TimePicker/TimePicker.test.tsx
+++ b/web/src/components/TimePicker/TimePicker.test.tsx
@@ -1,0 +1,14 @@
+import { render } from '@redwoodjs/testing/web'
+
+import TimePicker from './TimePicker'
+
+//   Improve this test with help from the Redwood Testing Doc:
+//    https://redwoodjs.com/docs/testing#testing-components
+
+describe('TimePicker', () => {
+  it('renders successfully', () => {
+    expect(() => {
+      render(<TimePicker />)
+    }).not.toThrow()
+  })
+})

--- a/web/src/components/TimePicker/TimePicker.tsx
+++ b/web/src/components/TimePicker/TimePicker.tsx
@@ -11,7 +11,7 @@ const TimePicker = ({ time, className }: TimePickerProps) => {
   return (
     <div
       className={cn(
-        'mx-auto flex items-center justify-center gap-5 py-10',
+        'mx-auto flex items-center justify-center gap-5 py-14',
         className
       )}
     >

--- a/web/src/components/TimePicker/TimePicker.tsx
+++ b/web/src/components/TimePicker/TimePicker.tsx
@@ -15,7 +15,7 @@ const TimePicker = ({ time, className }: TimePickerProps) => {
         className
       )}
     >
-      <span className="mx-auto text-2xl text-muted/50">12 Okt 2024</span>
+      <span className="mx-auto text-xl text-muted/50">12 Okt 2024</span>
       <input
         type="time"
         defaultValue={time}

--- a/web/src/components/TimePicker/TimePicker.tsx
+++ b/web/src/components/TimePicker/TimePicker.tsx
@@ -11,7 +11,7 @@ const TimePicker = ({ time, className }: TimePickerProps) => {
   return (
     <div
       className={cn(
-        'mx-auto flex items-center justify-center gap-5 py-14',
+        'mx-auto flex items-center justify-center gap-5 py-10',
         className
       )}
     >

--- a/web/src/components/TimePicker/TimePicker.tsx
+++ b/web/src/components/TimePicker/TimePicker.tsx
@@ -1,10 +1,26 @@
 import * as React from 'react'
 
-const TimePicker = () => {
+import { cn } from 'src/lib/utils'
+
+type TimePickerProps = {
+  time: string
+  className?: string
+}
+
+const TimePicker = ({ time, className }: TimePickerProps) => {
   return (
-    <div>
-      <h2>{'TimePicker'}</h2>
-      <p>{'Find me in ./web/src/components/TimePicker/TimePicker.tsx'}</p>
+    <div
+      className={cn(
+        'mx-auto flex items-center justify-center gap-5 py-10',
+        className
+      )}
+    >
+      <span className="mx-auto text-2xl text-muted/50">12 Okt 2024</span>
+      <input
+        type="time"
+        defaultValue={time}
+        className="rounded-sm bg-white px-2 text-center text-3xl text-primary"
+      />
     </div>
   )
 }

--- a/web/src/components/TimePicker/TimePicker.tsx
+++ b/web/src/components/TimePicker/TimePicker.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react'
+
+const TimePicker = () => {
+  return (
+    <div>
+      <h2>{'TimePicker'}</h2>
+      <p>{'Find me in ./web/src/components/TimePicker/TimePicker.tsx'}</p>
+    </div>
+  )
+}
+
+export default TimePicker

--- a/web/src/components/ui/drawer.tsx
+++ b/web/src/components/ui/drawer.tsx
@@ -1,7 +1,8 @@
-import * as React from "react"
-import { Drawer as DrawerPrimitive } from "vaul"
+import * as React from 'react'
 
-import { cn } from "src/lib/utils"
+import { Drawer as DrawerPrimitive } from 'vaul'
+
+import { cn } from 'src/lib/utils'
 
 const Drawer = ({
   shouldScaleBackground = true,
@@ -12,7 +13,7 @@ const Drawer = ({
     {...props}
   />
 )
-Drawer.displayName = "Drawer"
+Drawer.displayName = 'Drawer'
 
 const DrawerTrigger = DrawerPrimitive.Trigger
 
@@ -26,7 +27,7 @@ const DrawerOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DrawerPrimitive.Overlay
     ref={ref}
-    className={cn("fixed inset-0 z-50 bg-black/80", className)}
+    className={cn('fixed inset-0 z-50 bg-black/80', className)}
     {...props}
   />
 ))
@@ -41,39 +42,39 @@ const DrawerContent = React.forwardRef<
     <DrawerPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col rounded-t-[10px] border bg-background",
+        'fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col rounded-t-[10px] border bg-background',
         className
       )}
       {...props}
     >
-      <div className="mx-auto mt-4 h-2 w-[100px] rounded-full bg-muted" />
+      <div className="mx-auto mt-4 h-2 w-[100px] rounded-full bg-muted/20" />
       {children}
     </DrawerPrimitive.Content>
   </DrawerPortal>
 ))
-DrawerContent.displayName = "DrawerContent"
+DrawerContent.displayName = 'DrawerContent'
 
 const DrawerHeader = ({
   className,
   ...props
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
-    className={cn("grid gap-1.5 p-4 text-center sm:text-left", className)}
+    className={cn('grid gap-1.5 p-4 text-center sm:text-left', className)}
     {...props}
   />
 )
-DrawerHeader.displayName = "DrawerHeader"
+DrawerHeader.displayName = 'DrawerHeader'
 
 const DrawerFooter = ({
   className,
   ...props
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
-    className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+    className={cn('mt-auto flex flex-col gap-2 p-4', className)}
     {...props}
   />
 )
-DrawerFooter.displayName = "DrawerFooter"
+DrawerFooter.displayName = 'DrawerFooter'
 
 const DrawerTitle = React.forwardRef<
   React.ElementRef<typeof DrawerPrimitive.Title>,
@@ -82,7 +83,7 @@ const DrawerTitle = React.forwardRef<
   <DrawerPrimitive.Title
     ref={ref}
     className={cn(
-      "text-lg font-semibold leading-none tracking-tight",
+      'text-lg font-semibold leading-none tracking-tight',
       className
     )}
     {...props}
@@ -96,7 +97,7 @@ const DrawerDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DrawerPrimitive.Description
     ref={ref}
-    className={cn("text-sm text-muted-foreground", className)}
+    className={cn('text-sm text-muted-foreground', className)}
     {...props}
   />
 ))


### PR DESCRIPTION
This PR creates a ShiftConfirmationDrawer UI component for the client side. FIxes #236 

<img width="727" alt="Screenshot 2024-10-09 at 21 30 43" src="https://github.com/user-attachments/assets/d4decd20-23ab-4744-906e-d19ac43ea58d">

<img width="726" alt="Screenshot 2024-10-09 at 21 34 40" src="https://github.com/user-attachments/assets/eab060db-2581-4414-a1ff-da2440e9bb9b">

<img width="727" alt="Screenshot 2024-10-09 at 21 30 13" src="https://github.com/user-attachments/assets/0d8c5c91-ec8b-4b41-b5d7-19e26bf84a2e">

We need to hook this up, ASAP @nsunami  🙏🏽 I created an issue for you here:  #269 