### PR TITLE
Fixing Plan Work Dialogue layout

### DIFF
--- a/web/src/components/PlanWorkComponent/PlanWorkComponent.tsx
+++ b/web/src/components/PlanWorkComponent/PlanWorkComponent.tsx
@@ -360,7 +360,7 @@ const PlanWorkComponent = ({
                   </FormItem>
                 )}
               />
-              <fieldset className="flex flex-col items-center justify-between sm:flex-row">
+              <fieldset className="flex flex-wrap justify-between">
                 <FormField
                   control={form.control}
                   name="startDate"


### PR DESCRIPTION
This PR fixes the misalignment issue for the start and end date inputs. Fixes #249 

<img width="468" alt="Screenshot 2024-10-11 at 13 51 42" src="https://github.com/user-attachments/assets/6bf2dfb6-acc9-4104-8642-3ce79e9e384d">
