### PR TITLE
🛢️ Update the Shift model to handle check-in, check-out, and names of wokeres [skip ci]

### DIFF
--- a/api/db/migrations/20241011200057_add_check_in_and_out/migration.sql
+++ b/api/db/migrations/20241011200057_add_check_in_and_out/migration.sql
@@ -1,0 +1,14 @@
+-- AlterEnum
+-- This migration adds more than one value to an enum.
+-- With PostgreSQL versions 11 and earlier, this is not possible
+-- in a single migration. This can be worked around by creating
+-- multiple migrations, each migration adding only one value to
+-- the enum.
+
+
+ALTER TYPE "ShiftStatus" ADD VALUE 'CHECKED_IN';
+ALTER TYPE "ShiftStatus" ADD VALUE 'CHECKED_OUT';
+
+-- AlterTable
+ALTER TABLE "Shift" ADD COLUMN     "checkedInAt" TIMESTAMP(3),
+ADD COLUMN     "checkedOutAt" TIMESTAMP(3);

--- a/api/db/migrations/20241011200153_add_worker_name_to_shifts/migration.sql
+++ b/api/db/migrations/20241011200153_add_worker_name_to_shifts/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Shift" ADD COLUMN     "workerName" TEXT;

--- a/api/db/schema.prisma
+++ b/api/db/schema.prisma
@@ -139,6 +139,7 @@ model TempAgency {
 model Shift {
   id            String       @id @default(cuid())
   name          String?
+  workerName    String?
   createdAt     DateTime     @default(now())
   updatedAt     DateTime     @updatedAt
   status        ShiftStatus  @default(UNFULFILLED)

--- a/api/db/schema.prisma
+++ b/api/db/schema.prisma
@@ -149,11 +149,15 @@ model Shift {
   tempAgencyId  String?
   hoursPlanned  Decimal?
   hoursWorked   Decimal?
+  checkedInAt   DateTime?
+  checkedOutAt  DateTime?
 }
 
 enum ShiftStatus {
   UNFULFILLED
   FULFILLED
+  CHECKED_IN
+  CHECKED_OUT
 }
 
 model ClientBusiness {


### PR DESCRIPTION
This PR updates the Shift model so that we can track check-in & check-out times, and the names of workers.

Resolves #273 

Since this PR changes the database schema, don't forget to run `prisma migrate dev` after merging.