### PR TITLE
feat(ShiftStatus): Add checked-in and checked-out as shift statuses

### DIFF
--- a/api/src/graphql/shifts.sdl.ts
+++ b/api/src/graphql/shifts.sdl.ts
@@ -14,6 +14,8 @@ export const schema = gql`
   enum ShiftStatus {
     UNFULFILLED
     FULFILLED
+    CHECKED_IN
+    CHECKED_OUT
   }
 
   type Query {


### PR DESCRIPTION
This PR adds the CHECKED_IN and CHECKED_OUT enums introduced in the #40 to the GraphQL definitions (SDL). Without this the DB query was failing. 

![image](https://github.com/user-attachments/assets/30c83527-4db8-423e-a3d3-9e137b22cecf)
