### PR TITLE
Remove the Uitzendbureau from the DrawerMenu

### DIFF
--- a/web/src/components/DrawerMenu/DrawerMenu.tsx
+++ b/web/src/components/DrawerMenu/DrawerMenu.tsx
@@ -70,11 +70,6 @@ const DrawerMenu = () => {
                 <DrawerClose>Dashboard</DrawerClose>
               </Link>
             </li>
-            <li className="hover:text-accent">
-              <Link to={routes.tempAgencies()}>
-                <DrawerClose>Uitzendbureau</DrawerClose>
-              </Link>
-            </li>
           </ul>
         </section>
         <DrawerFooter className="relative self-center">


### PR DESCRIPTION
This PR removes the Uitzendbureau from the DrawerMenu. Fixes #291 