### PR TITLE
Replace login page tagline

### DIFF
--- a/web/src/pages/HomePage/HomePage.tsx
+++ b/web/src/pages/HomePage/HomePage.tsx
@@ -56,7 +56,7 @@ const HomePage = () => {
     <>
       <Metadata title="Home" description="Home page" />
 
-      <main className="min-h-screen w-full bg-primary">
+      <main className="min-h-screen bg-primary">
         <Toaster toastOptions={{ className: 'rw-toast', duration: 6000 }} />
         <div className="mx-auto flex w-full max-w-4xl flex-wrap items-center justify-center gap-4 py-20 md:py-52 lg:justify-between">
           <div className="flex w-full max-w-sm flex-col">

--- a/web/src/pages/HomePage/HomePage.tsx
+++ b/web/src/pages/HomePage/HomePage.tsx
@@ -65,9 +65,7 @@ const HomePage = () => {
               alt="logo"
               className="mx-auto w-48 drop-shadow-sm"
             />
-            <section className="mb-0 mt-2 text-center text-xl text-white drop-shadow-sm">
-              <p>Two liner</p>
-              <p>Fleckz mission tagline</p>
+            <section className="m-0 mt-2 px-2 text-center text-xl italic text-white/70 drop-shadow-sm md:text-2xl">
               <p>Vind je de beste kandidaat, overal.</p>
             </section>
           </div>

--- a/web/src/pages/HomePage/HomePage.tsx
+++ b/web/src/pages/HomePage/HomePage.tsx
@@ -68,6 +68,7 @@ const HomePage = () => {
             <section className="mb-0 mt-2 text-center text-xl text-white drop-shadow-sm">
               <p>Two liner</p>
               <p>Fleckz mission tagline</p>
+              <p>Vind je de beste kandidaat, overal.</p>
             </section>
           </div>
           <div className="form-wrapper m-0 flex w-11/12 max-w-sm flex-col rounded-md bg-black drop-shadow-sm">

--- a/web/src/pages/HomePage/HomePage.tsx
+++ b/web/src/pages/HomePage/HomePage.tsx
@@ -58,7 +58,7 @@ const HomePage = () => {
 
       <main className="min-h-screen w-full bg-primary">
         <Toaster toastOptions={{ className: 'rw-toast', duration: 6000 }} />
-        <div className="flex flex-wrap items-center justify-center gap-2 py-8 sm:py-24 md:py-36 lg:py-52">
+        <div className="mx-auto flex w-full max-w-4xl flex-wrap items-center justify-center gap-4 py-20 md:py-52 lg:justify-between">
           <div className="flex w-full max-w-sm flex-col">
             <img
               src={logo}


### PR DESCRIPTION
This PR updates the login page tagline placeholder.  Fixes #297 

<img width="1047" alt="Screenshot 2024-10-29 at 15 57 57" src="https://github.com/user-attachments/assets/5cc0b096-837d-4a2f-b7bc-279834759d78">
