### PR TITLE
ShiftConfirmationDrawer update

### DIFF
--- a/web/src/components/ShiftConfirmationDrawer/ShiftConfirmationDrawer.tsx
+++ b/web/src/components/ShiftConfirmationDrawer/ShiftConfirmationDrawer.tsx
@@ -4,6 +4,7 @@ import { FindWorkRequestQuery, WorkRequestsTodayQuery } from 'types/graphql'
 import { Button } from 'web/src/components/ui/button'
 import {
   Drawer,
+  DrawerBar,
   DrawerContent,
   DrawerTrigger,
 } from 'web/src/components/ui/drawer'
@@ -119,6 +120,7 @@ const ShiftConfirmationDrawer = ({ shift }: ShiftConfirmationDrawerProps) => {
         </Button>
       </DrawerTrigger>
       <DrawerContent className="container max-w-lg border-secondary/10 bg-gray-950 px-6 text-white/70">
+        <DrawerBar className="mb-2 mt-0" />
         <Tabs defaultValue="shiftCheckIn">
           <TabsList className="mx-auto mt-2 grid grid-cols-3 gap-2">
             <TabsTrigger


### PR DESCRIPTION
This PR adds the DrawerBar to the ShiftConfirmationDrawer content to indicate the direction the drawer opens from. Fixes #289 

<img width="530" alt="Screenshot 2024-10-30 at 16 09 29" src="https://github.com/user-attachments/assets/610970ee-5cd1-4dd8-9527-7b42124806fd">
