### PR TITLE
Site tagline update

### DIFF
--- a/web/src/pages/HomePage/HomePage.tsx
+++ b/web/src/pages/HomePage/HomePage.tsx
@@ -65,7 +65,7 @@ const HomePage = () => {
               alt="logo"
               className="mx-auto w-48 drop-shadow-sm"
             />
-            <section className="m-0 mt-2 px-2 text-center text-xl italic text-white/70 drop-shadow-sm md:text-2xl">
+            <section className="m-0 mt-4 px-2 text-center text-xl italic text-white/70 drop-shadow-sm md:text-2xl">
               <p>De zoekmachine voor uitzendkrchten</p>
             </section>
           </div>

--- a/web/src/pages/HomePage/HomePage.tsx
+++ b/web/src/pages/HomePage/HomePage.tsx
@@ -66,7 +66,7 @@ const HomePage = () => {
               className="mx-auto w-48 drop-shadow-sm"
             />
             <section className="m-0 mt-2 px-2 text-center text-xl italic text-white/70 drop-shadow-sm md:text-2xl">
-              <p>Vind je de beste kandidaat, overal.</p>
+              <p>De zoekmachine voor uitzendkrchten</p>
             </section>
           </div>
           <div className="form-wrapper m-0 flex w-11/12 max-w-sm flex-col rounded-md bg-black drop-shadow-sm">

--- a/web/src/pages/HomePage/HomePage.tsx
+++ b/web/src/pages/HomePage/HomePage.tsx
@@ -59,7 +59,7 @@ const HomePage = () => {
       <main className="min-h-screen bg-primary">
         <Toaster toastOptions={{ className: 'rw-toast', duration: 6000 }} />
         <div className="mx-auto flex w-full max-w-4xl flex-wrap items-center justify-center gap-4 py-20 md:py-52 lg:justify-between">
-          <div className="flex w-full max-w-sm flex-col">
+          <div className="flex w-full max-w-md flex-col">
             <img
               src={logo}
               alt="logo"

--- a/web/src/pages/HomePage/HomePage.tsx
+++ b/web/src/pages/HomePage/HomePage.tsx
@@ -66,7 +66,7 @@ const HomePage = () => {
               className="mx-auto w-48 drop-shadow-sm"
             />
             <section className="m-0 mt-4 px-2 text-center text-xl italic text-white/70 drop-shadow-sm md:text-2xl">
-              <p>De zoekmachine voor uitzendkrchten</p>
+              <p>De zoekmachine voor uitzendkrachten</p>
             </section>
           </div>
           <div className="form-wrapper m-0 flex w-11/12 max-w-sm flex-col rounded-md bg-black drop-shadow-sm">


### PR DESCRIPTION
This PR changes the site tagline to "De zoekmachine voor uitzendkrachten". Fixes #325 

<img width="1068" alt="Screenshot 2024-11-04 at 18 57 19" src="https://github.com/user-attachments/assets/190aa8a0-3ac2-4f5b-99f2-ff845f609604">

