### PR TITLE
fix: Can update the user info again

### DIFF
--- a/api/src/graphql/users.sdl.ts
+++ b/api/src/graphql/users.sdl.ts
@@ -47,7 +47,7 @@ export const schema = gql`
     salt: String
     resetToken: String
     resetTokenExpiresAt: DateTime
-    roles: [Role]!
+    roles: [Role]
   }
 
   type Mutation {

--- a/api/src/services/users/users.scenarios.ts
+++ b/api/src/services/users/users.scenarios.ts
@@ -6,6 +6,9 @@ export const standard = defineScenario<Prisma.UserCreateArgs>({
   user: {
     one: {
       data: {
+        id: 'example1',
+        firstName: 'Example First',
+        lastName: 'Example Last',
         updatedAt: '2024-09-01T17:28:16.471Z',
         email: 'String4740238',
         hashedPassword: 'String',

--- a/api/src/services/users/users.test.ts
+++ b/api/src/services/users/users.test.ts
@@ -25,25 +25,29 @@ describe('users', () => {
   scenario('creates a user', async () => {
     const result = await createUser({
       input: {
-        email: 'String94843',
+        firstName: 'First Name',
+        lastName: 'Last Name',
+        email: 'test@example.com',
         hashedPassword: 'String',
         salt: 'String',
         roles: ['CLIENT'],
       },
     })
 
-    expect(result.updatedAt).toEqual(new Date('2024-10-05T09:59:39.504Z'))
-    expect(result.email).toEqual('String94843')
+    expect(result.firstName).toEqual('First Name')
+    expect(result.lastName).toEqual('Last Name')
+    expect(result.email).toEqual('test@example.com')
+    expect(result.roles).toEqual(['CLIENT'])
   })
 
   scenario('updates a user', async (scenario: StandardScenario) => {
-    const original = (await user({ id: scenario.user.one.id })) as User
+    mockCurrentUser(scenario.user.one)
     const result = await updateUser({
-      id: original.id,
+      id: scenario.user.one.id,
       input: { lastName: 'new last name' },
     })
 
-    expect(result.updatedAt).toEqual(new Date('2024-10-06T09:59:39.504Z'))
+    expect(result.lastName).toEqual('new last name')
   })
 
   scenario('deletes a user', async (scenario: StandardScenario) => {


### PR DESCRIPTION
This PR fixes a bug where we cannot update the user info (Issue #333)

I made the GraphQL "role" input optional to fix this. 


Resolves #333 