### PR TITLE
fix(AssignWorker): Rename GraphQL to assignWorker to avoid namespace collision [skip ci]

### DIFF
--- a/web/src/components/AssignShiftWorkerDialog/AssignShiftWorkerDialog.tsx
+++ b/web/src/components/AssignShiftWorkerDialog/AssignShiftWorkerDialog.tsx
@@ -29,7 +29,7 @@ import ButtonWithLoader from 'src/components/ButtonWithLoader/ButtonWithLoader'
 import { QUERY as WORK_REQUEST_CELL_QUERY } from 'src/components/WorkRequestCell'
 
 const ASSIGN_WORKER_GQL = gql`
-  mutation updateShift($id: String!, $input: UpdateShiftInput!) {
+  mutation assignWorker($id: String!, $input: UpdateShiftInput!) {
     updateShift(id: $id, input: $input) {
       id
       workerName


### PR DESCRIPTION
This PR renames the GraphQL operation for assigning a worker to `assignWorker` so that it won't collide with another operation named `updateShift`

Resolves #339 