### PR TITLE
Change the api of the confirm action component [skip ci]

### DIFF
--- a/web/src/components/AddJobProfileModal/AddJobProfileModal.tsx
+++ b/web/src/components/AddJobProfileModal/AddJobProfileModal.tsx
@@ -445,7 +445,13 @@ const AddJobProfileModal = ({
                 actionText="Verwijderen"
                 loading={deleteLoading}
               >
-                Verwijderen
+                <ButtonWithLoader
+                  type="button"
+                  variant="destructive"
+                  loading={loading}
+                >
+                  Verwijderen
+                </ButtonWithLoader>
               </ConfirmAction>
               <Button
                 variant="outline"

--- a/web/src/components/ConfirmAction/ConfirmAction.test.tsx
+++ b/web/src/components/ConfirmAction/ConfirmAction.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { render, fireEvent } from '@testing-library/react'
+import { render, fireEvent } from '@redwoodjs/testing'
 
 import ConfirmAction from './ConfirmAction'
 

--- a/web/src/components/ConfirmAction/ConfirmAction.test.tsx
+++ b/web/src/components/ConfirmAction/ConfirmAction.test.tsx
@@ -1,22 +1,71 @@
-import { render } from '@redwoodjs/testing/web'
+import React from 'react'
+
+import { render, fireEvent } from '@testing-library/react'
 
 import ConfirmAction from './ConfirmAction'
 
-//   Improve this test with help from the Redwood Testing Doc:
-//    https://redwoodjs.com/docs/testing#testing-components
-
 describe('ConfirmAction', () => {
-  it('renders successfully', () => {
-    expect(() => {
-      render(
-        <ConfirmAction
-          title="Confirm this action"
-          description="Please confirm this action"
-          onConfirm={() => {}}
-        >
-          Bevestigen
-        </ConfirmAction>
-      )
-    }).not.toThrow()
+  it('renders the action button', () => {
+    const title = 'Example Title'
+    const description = 'Example Description'
+    const actionText = 'Example Action Text'
+    const onConfirm = jest.fn()
+    const { getByText } = render(
+      <ConfirmAction
+        title={title}
+        description={description}
+        actionText={actionText}
+        onConfirm={onConfirm}
+      >
+        <button>Click me</button>
+      </ConfirmAction>
+    )
+    expect(getByText('Click me')).toBeInTheDocument()
+  })
+
+  it('open the dialog when the action is clicked', () => {
+    const title = 'Example Title'
+    const description = 'Example Description'
+    const actionText = 'Example Action Text'
+    const onConfirm = jest.fn()
+    const { getByText } = render(
+      <ConfirmAction
+        title={title}
+        description={description}
+        actionText={actionText}
+        onConfirm={onConfirm}
+      >
+        <button>Click me</button>
+      </ConfirmAction>
+    )
+    const actionButton = getByText('Click me')
+
+    fireEvent.click(actionButton)
+    expect(getByText(title)).toBeInTheDocument()
+    expect(getByText(description)).toBeInTheDocument()
+    expect(getByText(actionText)).toBeInTheDocument()
+  })
+
+  it('calls onSubmit when the confirmation button is clicked on the dialog', () => {
+    const title = 'Example Title'
+    const description = 'Example Description'
+    const actionText = 'Example Action Text'
+    const onConfirm = jest.fn()
+    const { getByText } = render(
+      <ConfirmAction
+        title={title}
+        description={description}
+        actionText={actionText}
+        onConfirm={onConfirm}
+      >
+        <button>Click me</button>
+      </ConfirmAction>
+    )
+    const actionButton = getByText('Click me')
+    fireEvent.click(actionButton)
+
+    const confirmButton = getByText(actionText)
+    fireEvent.click(confirmButton)
+    expect(onConfirm).toHaveBeenCalledTimes(1)
   })
 })

--- a/web/src/components/ConfirmAction/ConfirmAction.tsx
+++ b/web/src/components/ConfirmAction/ConfirmAction.tsx
@@ -2,7 +2,6 @@ import { ReactNode } from 'react'
 
 import { ApolloError } from '@apollo/client/errors'
 
-import ButtonWithLoader from 'src/components/ButtonWithLoader/ButtonWithLoader'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -37,11 +36,7 @@ const ConfirmAction = ({
 }: ConfirmActionProps) => {
   return (
     <AlertDialog>
-      <AlertDialogTrigger asChild>
-        <ButtonWithLoader type="button" variant="destructive" loading={loading}>
-          {children}
-        </ButtonWithLoader>
-      </AlertDialogTrigger>
+      <AlertDialogTrigger asChild>{children}</AlertDialogTrigger>
       <AlertDialogContent>
         <AlertDialogHeader>
           <AlertDialogTitle>{title}</AlertDialogTitle>


### PR DESCRIPTION
This PR changes the API of the confirm action dialog component, so that the dialog trigger can be any element other than a button.

I wanted this when working on #306, where the Trash can icon is styled not red. 