### PR TITLE
Render the project name to individual work requests on Today Page, and link out to a corresponding Work Request Page

### DIFF
--- a/web/src/components/IndividualWorkRequestSection/IndividualWorkRequestSection.test.tsx
+++ b/web/src/components/IndividualWorkRequestSection/IndividualWorkRequestSection.test.tsx
@@ -1,6 +1,7 @@
+import { formatDate } from 'date-fns/format'
 import { WorkRequestsTodayQuery } from 'types/graphql'
 
-import { render, fireEvent } from '@redwoodjs/testing/web'
+import { render } from '@redwoodjs/testing/web'
 
 import IndividualWorkRequestSection from './IndividualWorkRequestSection'
 
@@ -26,19 +27,29 @@ describe('IndividualWorkRequestSection', () => {
     jobProfile: { id: 'job-id', name: 'Job Profile' },
   }
 
-  it('renders the section', () => {
+  it('renders project name', () => {
     const { getByText } = render(
       <IndividualWorkRequestSection workRequest={workRequest} />
     )
-    expect(getByText('Section title')).toBeInTheDocument()
+    expect(getByText(workRequest.projectName)).toBeInTheDocument()
+  })
+  it('renders job profile name', () => {
+    const { getByText } = render(
+      <IndividualWorkRequestSection workRequest={workRequest} />
+    )
+    expect(getByText(workRequest.jobProfile.name)).toBeInTheDocument()
   })
 
-  it('renders the header with correct text', () => {
+  it('renders the start and end times', () => {
     const { getByText } = render(
       <IndividualWorkRequestSection workRequest={workRequest} />
     )
-    expect(getByText('HH:mm-HH:mm')).toBeInTheDocument()
-    expect(getByText('Job Profile')).toBeInTheDocument()
+    expect(
+      getByText(formatDate(workRequest.startDate, 'HH:mm'))
+    ).toBeInTheDocument()
+    expect(
+      getByText(formatDate(workRequest.endDate, 'HH:mm'))
+    ).toBeInTheDocument()
   })
 
   it('renders the shifts table with correct data', () => {
@@ -47,31 +58,5 @@ describe('IndividualWorkRequestSection', () => {
     )
     expect(getByText('John Doe')).toBeInTheDocument()
     expect(getByText('Temp Agency')).toBeInTheDocument()
-  })
-
-  it('renders the shift confirmation drawer', () => {
-    const { getByText } = render(
-      <IndividualWorkRequestSection workRequest={workRequest} />
-    )
-    expect(getByText('Shift confirmation drawer text')).toBeInTheDocument()
-  })
-
-  it('toggles the checkbox correctly', () => {
-    const { getByRole } = render(
-      <IndividualWorkRequestSection workRequest={workRequest} />
-    )
-    const checkbox = getByRole('checkbox')
-    fireEvent.click(checkbox)
-    expect(checkbox).toBeChecked()
-  })
-
-  it('calls the onCheckedChange prop when the checkbox is clicked', () => {
-    const onCheckedChange = jest.fn()
-    const { getByRole } = render(
-      <IndividualWorkRequestSection workRequest={workRequest} />
-    )
-    const checkbox = getByRole('checkbox')
-    fireEvent.click(checkbox)
-    expect(onCheckedChange).toHaveBeenCalledTimes(1)
   })
 })

--- a/web/src/components/IndividualWorkRequestSection/IndividualWorkRequestSection.tsx
+++ b/web/src/components/IndividualWorkRequestSection/IndividualWorkRequestSection.tsx
@@ -5,6 +5,8 @@ import { format } from 'date-fns/format'
 import { Users } from 'lucide-react'
 import { WorkRequestsTodayQuery } from 'types/graphql'
 
+import { Link, routes } from '@redwoodjs/router'
+
 import ShiftConfirmationDrawer from 'src/components/ShiftConfirmationDrawer/ShiftConfirmationDrawer'
 import TempAgencyWorker from 'src/components/TempAgencyWorker'
 import TodayShiftsTable from 'src/components/TodayShiftsTable/TodayShiftsTable'
@@ -76,7 +78,15 @@ const IndividualWorkRequestSection = ({
   return (
     <section className="mb-20">
       <Separator className="mt-4 bg-primary-foreground/20" />
-      <h3 className="center mt-2 gap-2 text-center">
+      <h3 className="center mt-2 font-bold text-white/80">
+        <Link
+          to={routes.workRequest({ id: workRequest.id })}
+          className="hover:text-accent"
+        >
+          {workRequest.jobProfile.name}
+        </Link>
+      </h3>
+      <h3 className="center gap-2 text-center">
         <div
           className="flex gap-1"
           title={formatInterval(
@@ -92,7 +102,7 @@ const IndividualWorkRequestSection = ({
           orientation="vertical"
           className="h-4 w-[2px] bg-accent/20"
         />
-        <span>{workRequest.jobProfile.name}</span>
+        <span>{workRequest.projectName}</span>
       </h3>
       <div className="center gap-1">
         <span>{workRequest.shifts?.length}</span>


### PR DESCRIPTION
This PR renders the project name to the individual work requests on the Today Page, and places a link to the corresponding work request page.

Resolves #332 