### PR TITLE
Add navigation arrows on Today page to move between dates

### DIFF
--- a/api/src/graphql/workRequests.sdl.ts
+++ b/api/src/graphql/workRequests.sdl.ts
@@ -27,7 +27,7 @@ export const schema = gql`
 
   type Query {
     workRequests: [WorkRequest!]! @requireAuth
-    workRequestsToday: [WorkRequest!]! @requireAuth
+    workRequestsToday(date: DateTime): [WorkRequest!]! @requireAuth
     workRequest(id: String!): WorkRequest @requireAuth
   }
 

--- a/api/src/services/workRequests/workRequests.ts
+++ b/api/src/services/workRequests/workRequests.ts
@@ -19,9 +19,13 @@ export const workRequests: QueryResolvers['workRequests'] = () => {
   })
 }
 
-export const workRequestsToday: QueryResolvers['workRequests'] = () => {
+export const workRequestsToday: QueryResolvers['workRequests'] = ({
+  date,
+}: {
+  date?: Date
+}) => {
   const oneDay = 24 * 60 * 60 * 1000
-  const today = new Date()
+  const today = new Date(date) || new Date()
   const startOfDay = new Date(
     today.getFullYear(),
     today.getMonth(),

--- a/web/src/components/WorkRequestsTodayCell/WorkRequestsTodayCell.tsx
+++ b/web/src/components/WorkRequestsTodayCell/WorkRequestsTodayCell.tsx
@@ -25,8 +25,8 @@ export const QUERY: TypedDocumentNode<
   WorkRequestsTodayQuery,
   WorkRequestsTodayQueryVariables
 > = gql`
-  query WorkRequestsTodayQuery {
-    workRequestsToday: workRequestsToday {
+  query WorkRequestsTodayQuery($date: DateTime) {
+    workRequestsToday: workRequestsToday(date: $date) {
       id
       projectName
       startDate

--- a/web/src/lib/formatters.test.tsx
+++ b/web/src/lib/formatters.test.tsx
@@ -1,3 +1,7 @@
+import { addDays, subDays } from 'date-fns'
+import { format } from 'date-fns/format'
+import { nl } from 'date-fns/locale/nl'
+
 import { render, waitFor, screen } from '@redwoodjs/testing/web'
 
 import {
@@ -7,6 +11,7 @@ import {
   timeTag,
   jsonDisplay,
   checkboxInputTag,
+  formatDaysFromNow,
 } from './formatters'
 
 describe('formatEnum', () => {
@@ -188,5 +193,40 @@ describe('checkboxInputTag', () => {
   it('is disabled when unchecked', () => {
     render(checkboxInputTag(false))
     expect(screen.getByRole('checkbox')).toBeDisabled()
+  })
+})
+
+describe('formatDaysFromNow', () => {
+  it("returns 'vandaag' when the date is today", () => {
+    expect(formatDaysFromNow(new Date())).toBe('vandaag')
+  })
+
+  it("returns 'gisteren' if the date is yesterday", () => {
+    expect(formatDaysFromNow(subDays(new Date(), 1))).toBe('gisteren')
+  })
+
+  it("returns 'morgen' if the date is tomorrow", () => {
+    expect(formatDaysFromNow(addDays(new Date(), 1))).toBe('morgen')
+  })
+
+  it("returns 'volgende (day of week)' if the day is 2 days ahead from now", () => {
+    const dayAfterTomorrow = addDays(new Date(), 2)
+    expect(formatDaysFromNow(dayAfterTomorrow)).toBe(
+      `volgende ${format(dayAfterTomorrow, 'eeee', { locale: nl })}`
+    )
+  })
+
+  it("returns 'vorige (day of week)' if the day is 2 days behind from now", () => {
+    const dayBeforeYesterday = subDays(new Date(), 2)
+    expect(formatDaysFromNow(dayBeforeYesterday)).toBe(
+      `vorige ${format(dayBeforeYesterday, 'eeee', { locale: nl })}`
+    )
+  })
+
+  it('returns the day of the week in far ahead dates', () => {
+    const oneWeekFromNow = addDays(new Date(), 7)
+    expect(formatDaysFromNow(oneWeekFromNow)).toBe(
+      format(oneWeekFromNow, 'eeee', { locale: nl })
+    )
   })
 })

--- a/web/src/lib/formatters.tsx
+++ b/web/src/lib/formatters.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 
+import { formatRelative } from 'date-fns'
 import { format } from 'date-fns/format'
+import { nl } from 'date-fns/locale/nl'
 import humanize from 'humanize-string'
 
 const MAX_STRING_LENGTH = 150
@@ -59,4 +61,21 @@ export const timeTag = (dateTime?: string) => {
 
 export const checkboxInputTag = (checked: boolean) => {
   return <input type="checkbox" checked={checked} disabled />
+}
+
+export function formatDaysFromNow(date: Date) {
+  const formatRelativeLocale = {
+    lastWeek: "'vorige' eeee",
+    yesterday: "'gisteren'",
+    today: "'vandaag'",
+    tomorrow: "'morgen'",
+    nextWeek: "'volgende' eeee",
+    other: 'eeee',
+  }
+
+  const relativeNLlocale = {
+    ...nl,
+    formatRelative: (token) => formatRelativeLocale[token],
+  }
+  return formatRelative(date, new Date(), { locale: relativeNLlocale })
 }

--- a/web/src/pages/TodayPage/TodayPage.tsx
+++ b/web/src/pages/TodayPage/TodayPage.tsx
@@ -1,28 +1,49 @@
 import { useState } from 'react'
 
+import { addDays, isToday, subDays } from 'date-fns'
 import { format } from 'date-fns/format'
 import { nl } from 'date-fns/locale/nl'
-import { Calendar } from 'lucide-react'
+import { Calendar, ChevronLeft, ChevronRight, RotateCw } from 'lucide-react'
 
 import { Link, routes } from '@redwoodjs/router'
 import { Metadata } from '@redwoodjs/web'
 
 import PlanWorkComponent from 'src/components/PlanWorkComponent/PlanWorkComponent'
 import WorkRequestsTodayCell from 'src/components/WorkRequestsTodayCell'
+import { formatDaysFromNow } from 'src/lib/formatters'
 
 const TodayPage = () => {
   const [openDialog, setOpenDialog] = useState(false)
+  const [date, setDate] = useState(new Date())
   return (
     <>
       <Metadata title="Today" description="Today page" />
       <div className="mx-auto flex max-w-4xl flex-col">
-        <div className="flex flex-col items-center text-xl font-bold">
-          <h1 className="text-white/90">Vandaag</h1>
-          <span className="text-2xl font-medium text-accent">
-            {format(new Date(), 'd MMMM yyyy', { locale: nl })}
-          </span>
+        <div className="flex flex-row items-center justify-center">
+          <ChevronLeft
+            className="hover:cursor-pointer"
+            onClick={() => setDate((d) => subDays(d, 1))}
+          />
+          <div className="relative mx-4 flex flex-col items-center text-xl">
+            <span className="text-2xl font-medium text-accent">
+              {format(date, 'd MMMM yyyy', { locale: nl })}
+            </span>
+            <h1 className="text-lg text-primary-foreground">
+              {formatDaysFromNow(date)}
+            </h1>
+            <RotateCw
+              className={`absolute -right-6 -top-2 size-[22px] rounded-full bg-white/60 p-1 text-primary
+                hover:cursor-pointer
+                hover:bg-accent ${isToday(date) && 'invisible'}`}
+              onClick={() => setDate(new Date())}
+            />
+          </div>
+          <ChevronRight
+            className="hover:cursor-pointer"
+            onClick={() => setDate((d) => addDays(d, 1))}
+          />
         </div>
-        <WorkRequestsTodayCell />
+        <WorkRequestsTodayCell date={date.toISOString()} />
         <div className="center mx-auto gap-2">
           <PlanWorkComponent open={openDialog} setOpen={setOpenDialog} />
           <Link to={routes.plan()}>


### PR DESCRIPTION
This PR adds navigation arrows to move between dates on the Today page.

Fixes #349 