### PR TITLE
feat(workRequests): Only admin or client can update & delete requests

### DIFF
--- a/api/src/services/workRequests/workRequests.ts
+++ b/api/src/services/workRequests/workRequests.ts
@@ -103,6 +103,16 @@ export const createWorkRequest: MutationResolvers['createWorkRequest'] = ({
 
 export const updateWorkRequest: MutationResolvers['updateWorkRequest'] =
   async ({ id, input }) => {
+    const updateRequestRoles = [
+      'ADMIN',
+      'CLIENT',
+    ] as typeof context.currentUser.roles
+    const canUpdateRequest = context.currentUser.roles.some((role) =>
+      updateRequestRoles.includes(role)
+    )
+    if (!canUpdateRequest)
+      throw new ForbiddenError('Je mag een werkverzoek niet bijwerken')
+
     const existingWorkRequest = await db.workRequest.findUnique({
       where: {
         id,
@@ -161,6 +171,16 @@ export const updateWorkRequest: MutationResolvers['updateWorkRequest'] =
 export const deleteWorkRequest: MutationResolvers['deleteWorkRequest'] = ({
   id,
 }) => {
+  const updateRequestRoles = [
+    'ADMIN',
+    'CLIENT',
+  ] as typeof context.currentUser.roles
+  const canUpdateRequest = context.currentUser.roles.some((role) =>
+    updateRequestRoles.includes(role)
+  )
+  if (!canUpdateRequest)
+    throw new ForbiddenError('Je mag een werkverzoek niet bijwerken')
+
   return db.workRequest.delete({
     where: { id },
   })


### PR DESCRIPTION
This PR restricts updating and editing work requests to admins and clients. (so that temp agency reps won't be able to edit things).

This PR only includes backend codes. UI also needs to be changed so that users won't see functionalities there. 

Fixes #225 
