### PR TITLE
Show SelectAgency combo box only to admin

### DIFF
--- a/web/src/components/ShiftTable/ShiftTable.tsx
+++ b/web/src/components/ShiftTable/ShiftTable.tsx
@@ -32,7 +32,7 @@ const ShiftTable = ({ request, tempAgencies }: ShiftTableProps) => {
     checkInOutRoles.includes(role)
   )
 
-  const assignTempAgencyRoles = ['ADMIN'] as typeof currentUser.roles
+  const assignTempAgencyRoles = ['ADMIN', 'CLIENT'] as typeof currentUser.roles
   const showAssignTempAgencyAction = currentUser.roles.some((role) =>
     assignTempAgencyRoles.includes(role)
   )
@@ -62,14 +62,18 @@ const ShiftTable = ({ request, tempAgencies }: ShiftTableProps) => {
       {
         accessorKey: 'assignTempAgency',
         header: 'Uitzendbureau',
-        cell: ({ row }) => (
-          <SelectAgency
-            tempAgencies={tempAgencies}
-            selectedAgency={row.getValue('tempAgency')}
-            shiftId={row.getValue('id')}
-            request={request}
-          />
-        ),
+        cell: ({ row }) => {
+          return currentUser.roles.includes('CLIENT') ? (
+            <>{row.original.tempAgency?.name || 'geen toegewezen'}</>
+          ) : (
+            <SelectAgency
+              tempAgencies={tempAgencies}
+              selectedAgency={row.getValue('tempAgency')}
+              shiftId={row.getValue('id')}
+              request={request}
+            />
+          )
+        },
       },
       {
         accessorKey: 'assignWorker',

--- a/web/src/components/ShiftTable/ShiftTable.tsx
+++ b/web/src/components/ShiftTable/ShiftTable.tsx
@@ -32,6 +32,11 @@ const ShiftTable = ({ request, tempAgencies }: ShiftTableProps) => {
     checkInOutRoles.includes(role)
   )
 
+  const assignTempAgencyRoles = ['ADMIN'] as typeof currentUser.roles
+  const showAssignTempAgencyAction = currentUser.roles.some((role) =>
+    assignTempAgencyRoles.includes(role)
+  )
+
   const { shifts } = request
   const columns = useMemo<
     ColumnDef<FindWorkRequestQuery['workRequest']['shifts'][0]>[]
@@ -55,7 +60,7 @@ const ShiftTable = ({ request, tempAgencies }: ShiftTableProps) => {
         accessorKey: 'tempAgency',
       },
       {
-        accessorKey: 'agency',
+        accessorKey: 'assignTempAgency',
         header: 'Uitzendbureau',
         cell: ({ row }) => (
           <SelectAgency
@@ -88,6 +93,7 @@ const ShiftTable = ({ request, tempAgencies }: ShiftTableProps) => {
         columnVisibility: {
           status: false,
           tempAgency: false,
+          assignTempAgency: showAssignTempAgencyAction,
           assignWorker: showAssignWorkerAction,
           checkInOut: showCheckInOutAction,
         },


### PR DESCRIPTION
This PR removes the ability for clients and temp agency representatives to select or change TempAgency.  Fixes #348 

<img width="648" alt="Screenshot 2024-11-12 at 20 17 19" src="https://github.com/user-attachments/assets/bb83fc6b-674e-4616-8830-aa189495579f">

<img width="645" alt="Screenshot 2024-11-12 at 20 17 57" src="https://github.com/user-attachments/assets/b56fa138-0559-4099-a77f-8c16421b78f3">
