### PR TITLE
 Onboarding - add job profile step

### DIFF
--- a/web/src/components/OnboardingAddJobProfile/OnboardingAddJobProfile.tsx
+++ b/web/src/components/OnboardingAddJobProfile/OnboardingAddJobProfile.tsx
@@ -84,12 +84,12 @@ const EmptyState = ({ handleMakeProfile }: EmptyStateProps) => {
         </a>
       </span>
       <Button
-        className="mt-8 self-center bg-secondary py-4 text-lg"
+        className="mb-4 mt-12 flex gap-1 self-center bg-black p-5 text-lg text-accent shadow-md shadow-accent/20 hover:bg-accent hover:text-white"
         type="submit"
         onClick={handleMakeProfile}
       >
         <CirclePlus className="mr-2" size={20} />
-        Aanmaken
+        <span className="text-white">Aanmaken</span>
       </Button>
     </>
   )

--- a/web/src/components/OnboardingAddJobProfile/OnboardingAddJobProfile.tsx
+++ b/web/src/components/OnboardingAddJobProfile/OnboardingAddJobProfile.tsx
@@ -76,8 +76,13 @@ const EmptyState = ({ handleMakeProfile }: EmptyStateProps) => {
         src="images/active-tourist-hiking-mountain-man-wearing-backpack-enjoying-trekking-looking-snowcapped-peaks.svg"
         alt="A man with a backpack in mountains"
         width={300}
-        className="self-center"
+        className="self-center pb-2"
       />
+      <span className="-mt-6 text-center text-xs text-gray-500">
+        <a href="http://www.freepik.com">
+          Image designed by pch.vector / Freepik
+        </a>
+      </span>
       <Button
         className="mt-8 self-center bg-secondary py-4 text-lg"
         type="submit"
@@ -86,11 +91,6 @@ const EmptyState = ({ handleMakeProfile }: EmptyStateProps) => {
         <CirclePlus className="mr-2" size={20} />
         Aanmaken
       </Button>
-      <span className="mt-12 text-right text-xs text-gray-500">
-        <a href="http://www.freepik.com">
-          Image designed by pch.vector / Freepik
-        </a>
-      </span>
     </>
   )
 }


### PR DESCRIPTION
This PR restyles the CTA button on the add job profile onboarding step to match the one used on the JobProfile page. Fixes #447 

<img width="681" alt="Screenshot 2025-01-08 at 20 12 04" src="https://github.com/user-attachments/assets/593c923a-3117-461b-a401-27cce519e2e5" />
