### PR TITLE
feat(HireWorker): Encourage paying now after finding matches

### DIFF
--- a/web/src/components/HireWorker/HireWorker.tsx
+++ b/web/src/components/HireWorker/HireWorker.tsx
@@ -2,8 +2,8 @@ import { useContext, useState } from 'react'
 
 import {
   ArrowLeft,
+  CreditCard,
   Filter,
-  Flag,
   UserRound,
   UserRoundCheck,
 } from 'lucide-react'
@@ -48,10 +48,10 @@ const HireWorker = () => {
       {stage === 'Confirmed' ? (
         <Button
           className="self-end py-4 text-lg text-accent"
-          onClick={() => navigate(routes.overview())}
+          onClick={() => navigate(routes.invoice())}
         >
-          <Flag className="mr-1 size-4" />
-          Klaar
+          <CreditCard className="mr-1 size-4" />
+          Betaal nu
         </Button>
       ) : (
         <Button


### PR DESCRIPTION
This PR will show "Pay now" button after finding matches with the workers, at the end of the onboarding for clients. 

![image](https://github.com/user-attachments/assets/d2a5cbe8-44fd-43d5-b61d-a1be4ac92fb9)

Fixes #474 