### PR TITLE
Add Confirm Work Request page and enhance item handling

### DIFF
--- a/web/src/Routes.tsx
+++ b/web/src/Routes.tsx
@@ -40,6 +40,7 @@ const Routes = () => {
           <Route path="/dashboard" page={DashboardPage} name="dashboard" />
           <Route path="/invoice" page={InvoicePage} name="invoice" />
           <Route path="/candidates" page={CandidatesPage} name="candidates" />
+          <Route path="/confirm-work-request" page={ConfirmWorkRequestPage} name="confirmWorkRequest" />
         </Set>
         <Set wrap={WorkRequestPageLayout}>
           <Route path="/requests/{id}" page={WorkRequestPage} name="workRequest" />

--- a/web/src/components/WorkRequestsListItem/WorkRequestsListItem.tsx
+++ b/web/src/components/WorkRequestsListItem/WorkRequestsListItem.tsx
@@ -3,26 +3,42 @@ import { nl } from 'date-fns/locale/nl'
 import { Users } from 'lucide-react'
 import { WorkRequestsQuery } from 'types/graphql'
 
-import { navigate } from '@redwoodjs/router'
+import { navigate, routes } from '@redwoodjs/router'
+
+import { cn } from 'src/lib/utils'
 
 type WorkRequestsListItemProps = {
   request: WorkRequestsQuery['workRequests'][0]
+  className?: string
 }
 
-const WorkRequestsListItem = ({ request }: WorkRequestsListItemProps) => {
+const WorkRequestsListItem = ({
+  request,
+  className,
+}: WorkRequestsListItemProps) => {
   const accentColor =
     request.status === 'CONFIRMED'
       ? 'secondary'
       : request.status === 'DONE'
         ? 'green-800'
         : 'red-800'
+  function handleItemClick() {
+    if (request.status === 'SUBMITTED')
+      return navigate(
+        routes.confirmWorkRequest({ request: JSON.stringify(request) })
+      )
+    navigate(`/requests/${request.id}`)
+  }
   return (
     <div
       key={request.id}
       role="button"
       tabIndex={0}
-      className={`my-2 grid grid-cols-5 items-center gap-2 rounded-md bg-${accentColor} p-2 hover:cursor-pointer hover:bg-white/80 hover:text-${accentColor} xs:pl-6`}
-      onClick={() => navigate(`/requests/${request.id}`)}
+      className={cn(
+        `my-2 grid grid-cols-5 items-center gap-2 rounded-md bg-${accentColor} p-2 hover:cursor-pointer hover:bg-white/80 hover:text-${accentColor} xs:pl-6`,
+        className
+      )}
+      onClick={handleItemClick}
       onKeyDown={(e) => {
         if (e.key === 'Enter' || e.key === ' ') {
           navigate(`/requests/${request.id}`)

--- a/web/src/pages/ConfirmWorkRequestPage/ConfirmWorkRequestPage.stories.tsx
+++ b/web/src/pages/ConfirmWorkRequestPage/ConfirmWorkRequestPage.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import ConfirmWorkRequestPage from './ConfirmWorkRequestPage'
+
+const meta: Meta<typeof ConfirmWorkRequestPage> = {
+  component: ConfirmWorkRequestPage,
+}
+
+export default meta
+
+type Story = StoryObj<typeof ConfirmWorkRequestPage>
+
+export const Primary: Story = {}

--- a/web/src/pages/ConfirmWorkRequestPage/ConfirmWorkRequestPage.test.tsx
+++ b/web/src/pages/ConfirmWorkRequestPage/ConfirmWorkRequestPage.test.tsx
@@ -1,0 +1,14 @@
+import { render } from '@redwoodjs/testing/web'
+
+import ConfirmWorkRequestPage from './ConfirmWorkRequestPage'
+
+//   Improve this test with help from the Redwood Testing Doc:
+//   https://redwoodjs.com/docs/testing#testing-pages-layouts
+
+describe('ConfirmWorkRequestPage', () => {
+  it('renders successfully', () => {
+    expect(() => {
+      render(<ConfirmWorkRequestPage />)
+    }).not.toThrow()
+  })
+})

--- a/web/src/pages/ConfirmWorkRequestPage/ConfirmWorkRequestPage.tsx
+++ b/web/src/pages/ConfirmWorkRequestPage/ConfirmWorkRequestPage.tsx
@@ -1,0 +1,26 @@
+import { Metadata } from '@redwoodjs/web'
+
+const ConfirmWorkRequestPage = () => {
+  return (
+    <>
+      <Metadata
+        title="ConfirmWorkRequest"
+        description="ConfirmWorkRequest page"
+      />
+
+      <h1>ConfirmWorkRequestPage</h1>
+      <p>
+        Find me in{' '}
+        <code>
+          ./web/src/pages/ConfirmWorkRequestPage/ConfirmWorkRequestPage.tsx
+        </code>
+      </p>
+      {/*
+          My default route is named `confirmWorkRequest`, link to me with:
+          `<Link to={routes.confirmWorkRequest()}>ConfirmWorkRequest</Link>`
+      */}
+    </>
+  )
+}
+
+export default ConfirmWorkRequestPage

--- a/web/src/pages/ConfirmWorkRequestPage/ConfirmWorkRequestPage.tsx
+++ b/web/src/pages/ConfirmWorkRequestPage/ConfirmWorkRequestPage.tsx
@@ -1,24 +1,58 @@
+import { WorkRequestsQuery } from 'types/graphql'
+
 import { Metadata } from '@redwoodjs/web'
 
-const ConfirmWorkRequestPage = () => {
+import ConfirmAcceptWorkRequest from 'src/components/ConfirmAcceptWorkRequest/ConfirmAcceptWorkRequest'
+import { Avatar, AvatarFallback, AvatarImage } from 'src/components/ui/avatar'
+import WorkRequestsListItem from 'src/components/WorkRequestsListItem/WorkRequestsListItem'
+
+type ConfirmWorkRequestPageProps = {
+  request: string
+  workRequests: WorkRequestsQuery['workRequests']
+}
+
+const ConfirmWorkRequestPage = ({ request }: ConfirmWorkRequestPageProps) => {
+  const workRequest = JSON.parse(request)
   return (
     <>
       <Metadata
         title="ConfirmWorkRequest"
         description="ConfirmWorkRequest page"
       />
-
-      <h1>ConfirmWorkRequestPage</h1>
-      <p>
-        Find me in{' '}
-        <code>
-          ./web/src/pages/ConfirmWorkRequestPage/ConfirmWorkRequestPage.tsx
-        </code>
-      </p>
-      {/*
-          My default route is named `confirmWorkRequest`, link to me with:
-          `<Link to={routes.confirmWorkRequest()}>ConfirmWorkRequest</Link>`
-      */}
+      <div className="mx-auto flex max-w-4xl flex-col text-white">
+        <h1 className="flex items-center gap-1 text-xl font-bold">
+          Te bevestigen
+        </h1>
+        <div className="mt-2 flex flex-col gap-4 rounded-md bg-red-800 p-4 hover:bg-white hover:text-red-800">
+          <WorkRequestsListItem
+            key={workRequest.id}
+            request={workRequest}
+            className="mt-0 bg-red-800 text-white hover:cursor-none hover:bg-red-800 hover:text-white"
+          />
+          <li className="mx-auto flex w-full max-w-xl items-center justify-between gap-4">
+            <div className="flex w-full items-center gap-4 xs:gap-12">
+              <Avatar className="size-12">
+                <AvatarImage src={`https://avatar.iran.liara.run/public`} />
+                <AvatarFallback>
+                  <img
+                    src={`https://avatar.iran.liara.run/public`}
+                    alt="Random avatar"
+                  />
+                </AvatarFallback>
+              </Avatar>
+              <div className="flex flex-col">
+                <span>Hans van Manus</span>
+                <span>0612345678</span>
+              </div>
+            </div>
+            <ConfirmAcceptWorkRequest
+              onConfirm={() => {
+                /* handle confirm action */
+              }}
+            />
+          </li>
+        </div>
+      </div>
     </>
   )
 }

--- a/web/src/pages/ConfirmWorkRequestPage/ConfirmWorkRequestPage.tsx
+++ b/web/src/pages/ConfirmWorkRequestPage/ConfirmWorkRequestPage.tsx
@@ -23,13 +23,13 @@ const ConfirmWorkRequestPage = ({ request }: ConfirmWorkRequestPageProps) => {
         <h1 className="flex items-center gap-1 text-xl font-bold">
           Te bevestigen
         </h1>
-        <div className="mt-2 flex flex-col gap-4 rounded-md bg-red-800 p-4 hover:bg-white hover:text-red-800">
+        <ul className="mt-2 flex flex-col gap-4 rounded-md bg-red-800 p-4 hover:bg-white hover:text-red-800">
           <WorkRequestsListItem
             key={workRequest.id}
             request={workRequest}
             className="mt-0 bg-red-800 text-white hover:cursor-none hover:bg-red-800 hover:text-white"
           />
-          <li className="mx-auto flex w-full max-w-xl items-center justify-between gap-4">
+          <li className="mx-auto my-2 flex w-full max-w-xl items-center justify-between gap-4">
             <div className="flex w-full items-center gap-4 xs:gap-12">
               <Avatar className="size-12">
                 <AvatarImage src={`https://avatar.iran.liara.run/public`} />
@@ -51,7 +51,7 @@ const ConfirmWorkRequestPage = ({ request }: ConfirmWorkRequestPageProps) => {
               }}
             />
           </li>
-        </div>
+        </ul>
       </div>
     </>
   )


### PR DESCRIPTION
This PR introduces a new page for confirming work requests with improved routing and layout. Enhances item click handling in the work requests list to support navigation to the confirmation page.

Fixes #478

<img width="685" alt="Screenshot 2025-01-15 at 17 13 09" src="https://github.com/user-attachments/assets/e506ebb0-7b4c-4da1-bed3-df3f0d790515" />

<img width="684" alt="Screenshot 2025-01-15 at 17 12 52" src="https://github.com/user-attachments/assets/d708515a-c96a-4812-b978-6bab8b257ff7" />


